### PR TITLE
Replace `toLiquid` by `toArray`

### DIFF
--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -245,11 +245,13 @@ class Context
 		$object = $this->fetch(array_shift($parts));
 
 		if (is_object($object)) {
-			if (!method_exists($object, 'toArray')) {
-				throw new LiquidException("Method 'toArray' not exists!");
+			if (method_exists($object, 'toLiquid')) {
+				$object = $object->toLiquid();
+			} else if (method_exists($object, 'toArray')) {
+				$object = $object->toArray();
+			} else {
+				throw new LiquidException("Object has no `toLiquid` nor `toArray` method!");
 			}
-
-			$object = $object->toArray();
 		}
 
 		if ($object === null) {


### PR DESCRIPTION
This change is intended to make liquid adoption frictionless in PHP where the `toArray` method in an object is widely used to convert it into an array (even though not yet part of PHP's native `ArrayAccess` class.
