### PR TITLE
added support for hashes in for loops

### DIFF
--- a/src/Liquid/Tag/TagFor.php
+++ b/src/Liquid/Tag/TagFor.php
@@ -111,12 +111,10 @@ class TagFor extends AbstractBlock
 		$context->push();
 		$length = count($segment);
 
-		 // todo: If $segment keys are not integer, forloop not work
-		 // array_values is only a little help without being tested.
-		$segment = array_values($segment);
-
-		foreach ($segment as $index => $item) {
-			$context->set($this->variableName, $item);
+		$index = 0;
+		foreach ($segment as $key => $item) {
+			$value = is_numeric($key) ? $item : [$key, $item];
+			$context->set($this->variableName, $value);
 			$context->set('forloop', array(
 				'name' => $this->name,
 				'length' => $length,
@@ -128,6 +126,7 @@ class TagFor extends AbstractBlock
 				'last' => (int)($index == $length - 1)
 			));
 
+			$index++;
 			$result .= $this->renderAll($this->nodelist, $context);
 		}
 

--- a/src/Liquid/Tag/TagFor.php
+++ b/src/Liquid/Tag/TagFor.php
@@ -113,7 +113,7 @@ class TagFor extends AbstractBlock
 
 		$index = 0;
 		foreach ($segment as $key => $item) {
-			$value = is_numeric($key) ? $item : [$key, $item];
+			$value = is_numeric($key) ? $item : array($key, $item);
 			$context->set($this->variableName, $value);
 			$context->set('forloop', array(
 				'name' => $this->name,

--- a/tests/Liquid/Tag/TagForTest.php
+++ b/tests/Liquid/Tag/TagForTest.php
@@ -56,6 +56,10 @@ HERE;
 		$this->assertTemplateResult('abc', '{%for item in array%}{{item}}{%endfor%}', array('array' => array('a', '', 'b', '', 'c')));
 	}
 
+	public function testForWithHash() {
+   		$this->assertTemplateResult('a=b c=d e=f ', '{%for item in array%}{{item[0]}}={{item[1]}} {%endfor%}', array('array' => array('a' => 'b', 'c' => 'd', 'e' => 'f')));
+	}
+	
 	public function testForHelpers() {
 		$assigns = array('array' => array(1, 2, 3));
 


### PR DESCRIPTION
This adds support to use the following construct:

> When iterating a hash, item[0] contains the key, and item[1] contains the value:
> 
>     {% for item in hash %}
>       {{ item[0] }}: {{ item[1] }}
>     {% endfor %}

https://github.com/Shopify/liquid/wiki/Liquid-for-Designers#for-loops

The unit tests pass. But maybe I'm missing an edge case here. This could also introduce a BC break as users may use associative arrays/hashes without using the official syntax.