### PR TITLE
Cast an object to array if it has no `toLiquid` nor `toArray` methods

### DIFF
--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -251,7 +251,8 @@ class Context
 			} else if (method_exists($object, 'toArray')) {
 				$object = $object->toArray();
 			} else {
-				throw new LiquidException("Object has no `toLiquid` nor `toArray` method!");
+				// fetch public properties if nothing else works
+				$object = get_object_vars($object);
 			}
 		}
 

--- a/tests/Liquid/ContextTest.php
+++ b/tests/Liquid/ContextTest.php
@@ -25,7 +25,9 @@ class CentsDrop extends Drop
 	}
 }
 
-class NoToLiquid {}
+class NoToLiquid {
+	public $answer = 42;
+}
 
 class HiFilter
 {
@@ -99,12 +101,9 @@ class ContextTest extends TestCase
 		$this->assertNull($this->context->get('test'));
 	}
 
-	/**
-	 * @expectedException \Liquid\LiquidException
-	 */
 	public function testVariableIsObjectWithNoToLiquid() {
 		$this->context->set('test', new NoToLiquid());
-		$this->context->get('test');
+		$this->assertEquals(42, $this->context->get('test.answer'));
 	}
 
 	public function testVariables() {


### PR DESCRIPTION
If a developer didn't care (or couldn't care) to add `toLiquid` or `toArray` methods to an object he could have got from anywhere, don't just fail with an exception but use object's public variables.