### PR TITLE
Update access modifiers

### DIFF
--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -21,28 +21,28 @@ class Context
 	 *
 	 * @var array
 	 */
-	private $assigns;
+	protected $assigns;
 
 	/**
 	 * Registers for non-variable state data
 	 *
 	 * @var array
 	 */
-	public $registers;
+	protected $registers;
 
 	/**
 	 * The filterbank holds all the filters
 	 *
 	 * @var Filterbank
 	 */
-	private $filterbank;
+	protected $filterbank;
 
 	/**
 	 * Global scopes
 	 *
 	 * @var array
 	 */
-	public $environments = array();
+	protected $environments = array();
 
 	/**
 	 * Constructor

--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -28,7 +28,7 @@ class Context
 	 *
 	 * @var array
 	 */
-	protected $registers;
+	public $registers;
 
 	/**
 	 * The filterbank holds all the filters
@@ -42,7 +42,7 @@ class Context
 	 *
 	 * @var array
 	 */
-	protected $environments = array();
+	public $environments = array();
 
 	/**
 	 * Constructor


### PR DESCRIPTION
I used the module for one app I worked on and had to use a context class which extend the Liquid/Context. Updating the access modifiers from private to protected allowed me to read the assigned values from the extended class. This will add up more flexibility to the module. 