### PR TITLE
Escape-variables-by-default setting and raw pseudo-filter

### DIFF
--- a/src/Liquid/Liquid.php
+++ b/src/Liquid/Liquid.php
@@ -69,6 +69,9 @@ class Liquid
 
 		'QUOTED_STRING' => '"[^"]*"|\'[^\']*\'',
 		'QUOTED_STRING_FILTER_ARGUMENT' => '"[^":]*"|\'[^\':]*\'',
+
+		// Automatically escape any variables unless told otherwise by a "raw" filter
+		'ESCAPE_BY_DEFAULT' => false,
 	);
 
 	/**

--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -115,6 +115,17 @@ class StandardFilters
 	
 	
 	/**
+	 * Pseudo-filter: negates auto-added escape filter
+	 *
+	 * @param string $input
+	 *
+	 * @return string
+	 */
+	public static function raw($input) {
+		return $input;
+	}
+
+	/**
 	 * Escape a string
 	 *
 	 * @param string $input

--- a/src/Liquid/Variable.php
+++ b/src/Liquid/Variable.php
@@ -65,6 +65,30 @@ class Variable
 		} else {
 			$this->filters = array();
 		}
+
+		if (Liquid::get('ESCAPE_BY_DEFAULT')) {
+			// if auto_escape is enabled, and
+			// - there's no raw filter, and
+			// - no escape filter
+			// - no other standard html-adding filter
+			// then
+			// - add a mandatory escape filter
+
+			$addEscapeFilter = true;
+
+			foreach ($this->filters as $filter) {
+				// with empty filters set we would just move along
+				if (in_array($filter[0], array('escape', 'escape_once', 'raw', 'newline_to_br'))) {
+					// if we have any raw-like filter, stop
+					$addEscapeFilter = false;
+					break;
+				}
+			}
+
+			if ($addEscapeFilter) {
+				$this->filters[] = array('escape', array());
+			}
+		}
 	}
 
 	/**

--- a/tests/Liquid/EscapeByDefaultTest.php
+++ b/tests/Liquid/EscapeByDefaultTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * This file is part of the Liquid package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package Liquid
+ */
+
+namespace Liquid;
+
+class EscapeByDefaultTest extends TestCase
+{
+	const XSS = "<script>alert()</script>";
+	const XSS_FAILED = "&lt;script&gt;alert()&lt;/script&gt;";
+
+	protected $assigns = array();
+
+	protected function setup() {
+		parent::setUp();
+
+		$this->assigns = array(
+			'xss' => self::XSS,
+		);
+	}
+
+	public function testUnescaped() {
+		$text = "{{ xss }}";
+		$expected = self::XSS;
+		$this->assertTemplateResult($expected, $text, $this->assigns);
+	}
+
+	public function testEscapedManually() {
+		$text = "{{ xss | escape }}";
+		$expected = self::XSS_FAILED;
+		$this->assertTemplateResult($expected, $text, $this->assigns);
+	}
+
+	public function testRawWithoutAutoEscape() {
+		$text = "{{ xss | raw }}";
+		$expected = self::XSS;
+		$this->assertTemplateResult($expected, $text, $this->assigns);
+	}
+
+	public function testEscapedAutomatically() {
+		Liquid::set('ESCAPE_BY_DEFAULT', true);
+
+		$text = "{{ xss }}";
+		$expected = self::XSS_FAILED;
+		$this->assertTemplateResult($expected, $text, $this->assigns);
+	}
+
+	public function testEscapedManuallyInAutoMode() {
+		Liquid::set('ESCAPE_BY_DEFAULT', true);
+
+		// text should only be escaped once
+		$text = "{{ xss | escape }}";
+		$expected = self::XSS_FAILED;
+		$this->assertTemplateResult($expected, $text, $this->assigns);
+	}
+
+	public function testRawInAutoMode() {
+		Liquid::set('ESCAPE_BY_DEFAULT', true);
+
+		$text = "{{ xss | raw }}";
+		$expected = self::XSS;
+		$this->assertTemplateResult($expected, $text, $this->assigns);
+	}
+
+	public function testNlToBr() {
+		Liquid::set('ESCAPE_BY_DEFAULT', true);
+		$text = "{{ xss | newline_to_br }}";
+		$expected = self::XSS."<br />".self::XSS;
+		$this->assertTemplateResult($expected, $text, array('xss' => self::XSS."\n".self::XSS));
+	}
+
+	/** System default value for the escape flag */
+	private static $escapeDefault;
+
+	public static function setUpBeforeClass() {
+		// save system default value for the escape flag before all tests
+		self::$escapeDefault = Liquid::get('ESCAPE_BY_DEFAULT');
+	}
+
+	public function tearDown() {
+		// reset to the default after each test
+		Liquid::set('ESCAPE_BY_DEFAULT', self::$escapeDefault);
+	}
+}

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -104,6 +104,18 @@ class StandardFiltersTest extends TestCase
 		}
 	}
 
+	public function testRaw()
+	{
+		$data = array(
+			"Anything" => "Anything",
+			3 => 3,
+		);
+
+		foreach ($data as $element => $expected) {
+			$this->assertEquals($expected, StandardFilters::raw($element));
+		}
+	}
+
 	public function testEscape() {
 		$data = array(
 			"one Word's not" => "one Word&#39;s not",


### PR DESCRIPTION
This change adds [semi-context-aware auto-escaping](https://www.google.com/about/appsecurity/learning/xss/#TemplateSystems) for all variables as a guard against XSS. 

This behavior is turned off by default, so that all old scripts continue to work as usual.

```php
<?php
Liquid::set('ESCAPE_BY_DEFAULT', true);
$template = new Template();
$template->parse("{{ xss | escape }}\n{{ xss }}\n{{ xss | raw }}");
echo $template->render(array('xss' => "<script>alert()</script>"));
```
Ouputs:
```html
&lt;script&gt;alert()&lt;/script&gt;
&lt;script&gt;alert()&lt;/script&gt;
<script>alert()</script>
```
