### PR TITLE
Make Context work with plain object 

### DIFF
--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -250,10 +250,8 @@ class Context
 				$object = $object->toLiquid();
 			} else if (method_exists($object, 'toArray')) {
 				$object = $object->toArray();
-			} else {
-				// fetch public properties if nothing else works
-				$object = get_object_vars($object);
 			}
+			// we'll cover regular objects later
 		}
 
 		if ($object === null) {
@@ -295,17 +293,31 @@ class Context
 					call_user_func(array($object, Liquid::get('GET_PROPERTY_METHOD')), $nextPartName);
 				} else {
 					// if it's just a regular object, attempt to access a property
-					if (!property_exists($object, $nextPartName)) {
+					if (property_exists($object, $nextPartName)) {
+						$object = $object->$nextPartName;
+					} elseif (method_exists($object, $nextPartName)) {
+						// then try a method
+						$object = call_user_func(array($object, $nextPartName));
+					} else {
 						return null;
 					}
-
-					$object = $object->$nextPartName;
 				}
 			}
+		}
 
-			if (is_object($object) && method_exists($object, 'toLiquid')) {
+		// finally, resolve objects to values
+		if (is_object($object)) {
+			if (method_exists($object, '__toString')) {
+				$object = (string) $object;
+			} elseif (method_exists($object, 'toLiquid')) {
 				$object = $object->toLiquid();
 			}
+		}
+
+		// if everything else fails, throw up
+		if (is_object($object)) {
+			$class = get_class($object);
+			throw new LiquidException("Value of type $class has no `toLiquid` nor `__toString` method");
 		}
 
 		return $object;

--- a/tests/Liquid/ContextTest.php
+++ b/tests/Liquid/ContextTest.php
@@ -27,6 +27,14 @@ class CentsDrop extends Drop
 
 class NoToLiquid {
 	public $answer = 42;
+
+	public function count() {
+		return 1;
+	}
+
+	public function __toString() {
+		return "forty two";
+	}
 }
 
 class HiFilter
@@ -104,6 +112,16 @@ class ContextTest extends TestCase
 	public function testVariableIsObjectWithNoToLiquid() {
 		$this->context->set('test', new NoToLiquid());
 		$this->assertEquals(42, $this->context->get('test.answer'));
+		$this->assertEquals(1, $this->context->get('test.count'));
+		$this->assertEquals("forty two", $this->context->get('test'));
+	}
+
+	/**
+	 * @expectedException \Liquid\LiquidException
+	 */
+	public function testFinalVariableIsObject() {
+		$this->context->set('test', (object) array('value' => (object) array()));
+		$this->context->get('test.value');
 	}
 
 	public function testVariables() {


### PR DESCRIPTION
Make `Context` work with plain object as it should [since the beginning of times](https://github.com/kalimatas/php-liquid/commit/ad11834994e2716733281f3a8dacdebfce7c279b#diff-2669f12658bb0e3d54b9ded69c4bcccaR315) (and as it was before ca4b64f9494 so that no casting to array needed).

For a regular object, attempt to access a public property, and then try calling a method.

No exception thrown for initial objects not having `toLiquid` method, but if we come to have an object not having that or `__toString` method, we'll throw exception. In this case we really don't have a choice because we can't show simple objects as strings.

Method `__toString` has preference because `toLiquid` may return an array.