### PR TITLE
escape should use htmlentities; escape_once should simply work

### DIFF
--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -122,42 +122,21 @@ class StandardFilters
 	 * @return string
 	 */
 	public static function escape($input) {
-		
-		return is_string($input) ? str_replace(array('&', '>', '<', '"', "'"), array('&amp;', '&gt;', '&lt;', '&quot;', '&#39;'), $input) : $input;
-
+		return is_string($input) ? htmlentities($input, ENT_QUOTES) : $input;
 	}
-	
-	
+
+
 	/**
-	 * Escape a string once
+	 * Escape a string once, keeping all previous HTML entities intact
 	 *
 	 * @param string $input
 	 *
 	 * @return string
 	 */
 	public static function escape_once($input) {
-		
-		preg_match('/["><\']|&(?!([a-zA-Z]+|(#\d+));)/', $input, $matches);
-		
-		if (sizeof($matches) > 0){
-			
-			$pos = strpos($input, $matches[0]);			
-			if ($pos !== false) {
-				
-				$partial = substr($input, 0, $pos + 1);
-				$remaining = substr($input, $pos + 1);
-				
-			    $partial = str_replace(array('&', '>', '<', '"', "'"), array('&amp;', '&gt;', '&lt;', '&quot;', '&#39;'), $partial);
-			    
-			    $input = $partial.$remaining;
-			    
-			}
-			
-		}
-		
-		return $input;
+		return is_string($input) ? htmlentities($input, ENT_QUOTES, null, false) : $input;
 	}
-	
+
 
 	/**
 	 * Returns the first element of an array

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -106,19 +106,21 @@ class StandardFiltersTest extends TestCase
 
 	public function testEscape() {
 		$data = array(
-			"one Word's not" => "one Word&#39;s not",
-			3 => 3,
+			"one Word's not" => "one Word&#039;s not",
+			"&><\"'" => "&amp;&gt;&lt;&quot;&#039;",
 		);
 
 		foreach ($data as $element => $expected) {
 			$this->assertEquals($expected, StandardFilters::escape($element));
 		}
 	}
-	
+
 	public function testEscapeOnce() {
 		$data = array(
-			"one Word's not 'twas" => "one Word&#39;s not 'twas",
-			3 => 3,
+			"<b><script>alert()</script>" => "&lt;b&gt;&lt;script&gt;alert()&lt;/script&gt;",
+			"a < b & c" => "a &lt; b &amp; c",
+			"a &lt; b &amp; c" => "a &lt; b &amp; c",
+			"&lt;\">" => "&lt;&quot;&gt;",
 		);
 
 		foreach ($data as $element => $expected) {


### PR DESCRIPTION
`escape_once` didn't really work at least since 291837915ff

For example, from this:
```html
<b><script>alert()</script>
```
It used to make
```html
&lt;b><script>alert()</script>
```
Which is, well, a clear XSS and a failure.

[How it is expected to work in Ruby.](https://shopify.github.io/liquid/filters/escape_once/)