### PR TITLE
Allow negative numbers & Support strings and variables as array indicies

### DIFF
--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -240,6 +240,17 @@ class Context
 		if (preg_match("|\[[0-9]+\]|", $key)) {
 			$key = preg_replace("|\[([0-9]+)\]|", ".$1", $key);
 		}
+		
+		// Support names as array indicies
+		if (preg_match("|\[(".Liquid::get('ALLOWED_VARIABLE_CHARS')."+)\]|", $key, $matches)) {
+			// this is probably a variable
+			$var = $this->variable($matches[1]);
+			if (is_null($var)) { // is not a variable
+				$key = preg_replace("|\[(".Liquid::get('ALLOWED_VARIABLE_CHARS')."+)\]|", ".$1", $key);	
+			} else {
+				$key = preg_replace("|\[(".Liquid::get('ALLOWED_VARIABLE_CHARS')."+)\]|", ".".$this->variable($matches[1]), $key);
+			}
+		}
 
 		$parts = explode(Liquid::get('VARIABLE_ATTRIBUTE_SEPARATOR'), $key);
 

--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -245,10 +245,10 @@ class Context
 		if (preg_match("|\[(".Liquid::get('ALLOWED_VARIABLE_CHARS')."+)\]|", $key, $matches)) {
 			// this is probably a variable
 			$var = $this->variable($matches[1]);
-			if (is_null($var)) { // is not a variable
+			if (is_null($var) || !is_string($var)) { // is not a variable
 				$key = preg_replace("|\[(".Liquid::get('ALLOWED_VARIABLE_CHARS')."+)\]|", ".$1", $key);	
 			} else {
-				$key = preg_replace("|\[(".Liquid::get('ALLOWED_VARIABLE_CHARS')."+)\]|", ".".$this->variable($matches[1]), $key);
+				$key = preg_replace("|\[(".Liquid::get('ALLOWED_VARIABLE_CHARS')."+)\]|", ".".$var), $key);
 			}
 		}
 

--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -187,11 +187,11 @@ class Context
 			return $matches[1];
 		}
 
-		if (preg_match('/^(\d+)$/', $key, $matches)) {
+		if (preg_match('/^(-?\d+)$/', $key, $matches)) {
 			return $matches[1];
 		}
 
-		if (preg_match('/^(\d[\d\.]+)$/', $key, $matches)) {
+		if (preg_match('/^(-?\d[\d\.]+)$/', $key, $matches)) {
 			return $matches[1];
 		}
 


### PR DESCRIPTION
`{% assign i = -100 %}` or `{% assign i = -10.0 %}` was not possible, is possible now.

TODO:
- [ ] Test numbers in `TagAssignTest.php` 
