### PR TITLE
Remove content injection from $_GET in \Liquid\Context

### DIFF
--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -54,7 +54,8 @@ class Context
 		$this->assigns = array($assigns);
 		$this->registers = $registers;
 		$this->filterbank = new Filterbank($this);
-		$this->environments = array($_GET, $_SERVER);
+		// first empty array serves as source for ovverides, e.g. as in TagDecrement
+		$this->environments = array(array(), $_SERVER);
 	}
 
 	/**
@@ -206,6 +207,7 @@ class Context
 	 * @return mixed
 	 */
 	private function fetch($key) {
+		// TagDecrement depends on environments being checked before assigns
 		foreach ($this->environments as $environment) {
 			if (array_key_exists($key, $environment)) {
 				return $environment[$key];

--- a/tests/Liquid/ContextTest.php
+++ b/tests/Liquid/ContextTest.php
@@ -206,4 +206,13 @@ class ContextTest extends TestCase
 		$this->context->merge(array('cents' => array('cents' => array('cents' => new CentsDrop()))));
 		$this->assertEquals(100, $this->context->get('cents.cents.cents.amount'));
 	}
+
+	public function testGetNoOverride() {
+		$_GET['test'] = '<script>alert()</script>';
+		// Previously $_GET would override directly set values
+		// It happend during class construction - we need to create a brand new instance right here
+		$context = new Context();
+		$context->set('test', 'test');
+		$this->assertEquals('test', $context->get('test'));
+	}
 }


### PR DESCRIPTION
Currently if one knows exact names for variables in a template, then it is possible to insert arbitrary text in a template.

Consider this template:

```
<p>Hello, {{ name }}</p>
```

Even if you'd call it like so:

```
$template = new \Liquid\Template();
$template->parse(file_get_contents($templateFile));
echo $template->render(['name' => 'Alice']);
```

Anyone knowledgeable villain could override `{{ name }}` by passing a GET parameter with the same name:

```
http://example.com/profile?name=Bob
```

Moreover, since we don't escape tags by default, there's a certain opportunity for XSS.
