### PR TITLE
Math filters should not cast to int

### DIFF
--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -272,10 +272,10 @@ class StandardFilters
 	 * @param float $input
 	 * @param float $operand
 	 *
-	 * @return int
+	 * @return float
 	 */
 	public static function modulo($input, $operand) {
-		return (float)$input % (float)$operand;
+		return fmod((float)$input, (float)$operand);
 	}
 	
 	

--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -92,13 +92,13 @@ class StandardFilters
 	/**
 	 * division
 	 *
-	 * @param int $input
-	 * @param int $operand
+	 * @param float $input
+	 * @param float $operand
 	 *
-	 * @return int
+	 * @return float
 	 */
 	public static function divided_by($input, $operand) {
-		return (int)$input / (int)$operand;
+		return (float)$input / (float)$operand;
 	}
 		
 	
@@ -256,27 +256,27 @@ class StandardFilters
 	/**
 	 * subtraction
 	 *
-	 * @param int $input
-	 * @param int $operand
+	 * @param float $input
+	 * @param float $operand
 	 *
-	 * @return int
+	 * @return float
 	 */
 	public static function minus($input, $operand) {
-		return (int)$input - (int)$operand;
+		return (float)$input - (float)$operand;
 	}
 	
 	
 	/**
 	 * modulo
 	 *
-	 * @param int $input
-	 * @param int $operand
+	 * @param float $input
+	 * @param float $operand
 	 *
 	 * @return int
 	 */
 	public static function modulo($input, $operand) {
-		return (int)$input % (int)$operand;
-	}	
+		return (float)$input % (float)$operand;
+	}
 	
 	
 	/**
@@ -296,14 +296,14 @@ class StandardFilters
 	/**
 	 * addition
 	 *
-	 * @param int $input
-	 * @param int $operand
+	 * @param float $input
+	 * @param float $operand
 	 *
-	 * @return int
+	 * @return float
 	 */
 	public static function plus($input, $operand) {
-		return (int)$input + (int)$operand;
-	}	
+		return (float)$input + (float)$operand;
+	}
 	
 
 	/**
@@ -550,13 +550,13 @@ class StandardFilters
 	/**
 	 * multiplication
 	 *
-	 * @param int $input
-	 * @param int $operand
+	 * @param float $input
+	 * @param float $operand
 	 *
-	 * @return int
+	 * @return float
 	 */
 	public static function times($input, $operand) {
-		return (int)$input * (int)$operand;
+		return (float)$input * (float)$operand;
 	}
 	
 

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -768,12 +768,12 @@ class StandardFiltersTest extends TestCase
 			array(
 				1.5,
 				2.7,
-				3,
+				4.2,
 			),
 		);
 
 		foreach ($data as $item) {
-			$this->assertSame($item[2], StandardFilters::plus($item[0], $item[1]));
+			$this->assertEquals($item[2], StandardFilters::plus($item[0], $item[1]), '', 0.00001);
 		}
 	}
 
@@ -792,12 +792,12 @@ class StandardFiltersTest extends TestCase
 			array(
 				1.5,
 				2.7,
-				-1,
+				-1.2,
 			),
 		);
 
 		foreach ($data as $item) {
-			$this->assertSame($item[2], StandardFilters::minus($item[0], $item[1]));
+			$this->assertEquals($item[2], StandardFilters::minus($item[0], $item[1]), '', 0.00001);
 		}
 	}
 
@@ -816,12 +816,12 @@ class StandardFiltersTest extends TestCase
 			array(
 				1.5,
 				2.7,
-				2,
+				4.05,
 			),
 		);
 
 		foreach ($data as $item) {
-			$this->assertSame($item[2], StandardFilters::times($item[0], $item[1]));
+			$this->assertEquals($item[2], StandardFilters::times($item[0], $item[1]), '', 0.00001);
 		}
 	}
 
@@ -842,10 +842,15 @@ class StandardFiltersTest extends TestCase
 				200,
 				0,
 			),
+			array(
+				10,
+				0.5,
+				20,
+			),
 		);
 
 		foreach ($data as $item) {
-			$this->assertSame($item[2], StandardFilters::divided_by($item[0], $item[1]));
+			$this->assertEquals($item[2], StandardFilters::divided_by($item[0], $item[1]), '', 0.00001);
 		}
 	}
 
@@ -864,6 +869,11 @@ class StandardFiltersTest extends TestCase
 			array(
 				8,
 				3,
+				2,
+			),
+			array(
+				8.9,
+				3.5,
 				2,
 			),
 		);

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -874,12 +874,17 @@ class StandardFiltersTest extends TestCase
 			array(
 				8.9,
 				3.5,
-				2,
+				1.9,
+			),
+			array(
+				183.357,
+				12,
+				3.357,
 			),
 		);
 
 		foreach ($data as $item) {
-			$this->assertSame($item[2], StandardFilters::modulo($item[0], $item[1]));
+			$this->assertEquals($item[2], StandardFilters::modulo($item[0], $item[1]), '', 0.00001);
 		}
 	}
 


### PR DESCRIPTION
Shopify's liquid does just so.

For example, [see here an example of minus op on floats](https://shopify.github.io/liquid/filters/minus/).

Fixes #27