### PR TITLE
Match output of original Ruby method

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Liquid was written to meet three templating library requirements: good performan
 
 You can install this lib via [composer](https://getcomposer.org/):
 
-    composer create-project liquid/liquid
+    composer require liquid/liquid
 
 ## Example template
 

--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -287,12 +287,10 @@ class StandardFilters
 	 *
 	 * @return string
 	 */
-	public static function newline_to_br($input) {
-		return is_string($input) ? str_replace(array(
-			"\n", "\r"
-		), '<br />', $input) : $input;
-	}	
-	
+    public static function newline_to_br($input) {
+        return is_string($input) ? str_replace("\n", "<br />\n", $input) : $input;
+    }
+    	
 
 	/**
 	 * addition

--- a/tests/Liquid/EscapeByDefaultTest.php
+++ b/tests/Liquid/EscapeByDefaultTest.php
@@ -72,7 +72,7 @@ class EscapeByDefaultTest extends TestCase
 	public function testNlToBr() {
 		Liquid::set('ESCAPE_BY_DEFAULT', true);
 		$text = "{{ xss | newline_to_br }}";
-		$expected = self::XSS."<br />".self::XSS;
+		$expected = self::XSS."<br />\n".self::XSS;
 		$this->assertTemplateResult($expected, $text, array('xss' => self::XSS."\n".self::XSS));
 	}
 

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -155,7 +155,7 @@ class StandardFiltersTest extends TestCase
 
 	public function testNewLineToBr() {
 		$data = array(
-			"one Word\r\n not\r\n" => "one Word<br /><br /> not<br /><br />",
+			"one Word\n not\n" => "one Word<br />\n not<br />\n",
 			'test' => 'test',
 			3 => 3,
 		);


### PR DESCRIPTION
The original Ruby method only replaces **\n** characters:

```
def newline_to_br(input)
      input.to_s.gsub(/\n/, "<br />\n".freeze)
end
```
Replacing both **\n** and **\r** - as the PHP port currently does - can lead to double-carriage returns in some cases.

We should aim to match the original behavior of the Ruby implementation as closely as possible.