### PR TITLE
Standardize functions to match original implementation

### DIFF
--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -640,8 +640,18 @@ class StandardFilters
 	public static function url_encode($input) {
 		return urlencode($input);
 	}
-	
-	
+
+	/**
+	 * Decodes a URL-encoded string
+	 *
+	 * @param string $input
+	 *
+	 * @return string
+	 */
+	public static function url_decode($input) {
+		return urldecode($input);
+	}
+
 	/**
 	 * Use overloading to get around reserved php words - in this case 'default'
 	 *

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -984,5 +984,9 @@ class StandardFiltersTest extends TestCase
 		$var = new Variable("var | date: '%d/%m/%Y %l:%M %p'");
 		$this->context->set('var', '2017-07-01 21:00:00');
 		$this->assertEquals('01/07/2017  9:00 PM', $var->render($this->context));
+
+		$var = new Variable('var | date, ""');
+		$this->context->set('var', '2017-07-01 21:00:00');
+		$this->assertEquals('', $var->render($this->context));
 	}
 }

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -105,6 +105,29 @@ class StandardFiltersTest extends TestCase
 		}
 	}
 
+	public function testUrlEncode() {
+		$data = array(
+			'nothing' => 'nothing',
+			'%#&^' => '%25%23%26%5E',
+		);
+
+		foreach ($data as $element => $expected) {
+			$this->assertEquals($expected, StandardFilters::url_encode($element));
+		}
+	}
+
+
+	public function testUrlDecode() {
+		$data = array(
+			'%25%23%26%5E' => '%#&^',
+		);
+
+		foreach ($data as $element => $expected) {
+			$this->assertEquals($expected, StandardFilters::url_decode($element));
+		}
+	}
+
+
 	public function testRaw()
 	{
 		$data = array(

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -817,6 +817,11 @@ class StandardFiltersTest extends TestCase
 				2.7,
 				-1.2,
 			),
+			array(
+			    3.1,
+			    3.1,
+			    0
+			)
 		);
 
 		foreach ($data as $item) {
@@ -841,6 +846,11 @@ class StandardFiltersTest extends TestCase
 				2.7,
 				4.05,
 			),
+			array(
+			      7.5,
+			      0,
+			      0
+			)
 		);
 
 		foreach ($data as $item) {
@@ -970,6 +980,10 @@ class StandardFiltersTest extends TestCase
 				0.42,
 				0,
 			),
+			array(
+				2.5,
+				2,
+			)
 		);
 
 		foreach ($data as $item) {


### PR DESCRIPTION
Mostly taken from harrydeluxe/php-liquid#43 with most work done by @schmoove

`date()` - already returns empty value if $input is empty, added test coverage
`url_decode()` - currently missing, added test coverage
divided_by(), minus(), plus(), times() - all being tested with floats
