### PR TITLE
Require PHP 5.6 no less

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: false
 
 language: php
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* master
+
+ * Dropped support for EOL'ed versions of PHP (< 5.6)
+
 * 1.3.1 (2017-09-23)
 
  * Support for numeric and variable array indicies

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To find more examples have a look at the `examples` directory or at the original
 
 ## Requirements
 
- * PHP 5.4+
+ * PHP 5.6+
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ To find more examples have a look at the `examples` directory or at the original
 
  * PHP 5.6+
 
+Package versions below 1.4 could be used with PHP 5.3/5.4/5.5.
+
 ## Issues
 
 Have a bug? Please create an issue here on GitHub!

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         }
     ],
     "require": {
-        "php": ">= 5.3"
+        "php": ">= 5.6"
     },
     "require-dev": {
         "phpunit/phpunit": "<6",

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,11 @@
         },
         {
             "name": "Mateo Murphy"
+        },
+        {
+            "name": "Alexey Kopytko",
+            "email": "alexey@kopytko.com",
+            "homepage": "https://www.alexeykopytko.com/"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,38 +1,41 @@
 {
     "name": "liquid/liquid",
     "description": "Liquid template engine for PHP",
-	"keywords": ["liquid", "template"],
-	"homepage": "https://github.com/kalimatas/php-liquid",
+    "keywords": [
+        "liquid",
+        "template"
+    ],
+    "homepage": "https://github.com/kalimatas/php-liquid",
     "license": "MIT",
-	"type": "library",
+    "type": "library",
     "authors": [
         {
             "name": "Guz Alexander",
             "email": "kalimatas@gmail.com",
-			"homepage": "http://guzalexander.com"
+            "homepage": "http://guzalexander.com"
         },
-		{
-			"name": "Harald Hanek"
-		},
-		{
-			"name": "Mateo Murphy"
-		}
+        {
+            "name": "Harald Hanek"
+        },
+        {
+            "name": "Mateo Murphy"
+        }
     ],
     "require": {
-		"php": ">= 5.3"
-	},
-	"require-dev": {
-		"phpunit/phpunit": "<6",
-		"satooshi/php-coveralls": "^1.0"
-	},
-	"autoload": {
-		"psr-4": {
-			"Liquid\\": "src/Liquid"
-		}
-	},
-	"autoload-dev": {
-		"psr-4": {
-			"Liquid\\": "tests/Liquid"
-		}
-	}
+        "php": ">= 5.3"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "<6",
+        "satooshi/php-coveralls": "^1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Liquid\\": "src/Liquid"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Liquid\\": "tests/Liquid"
+        }
+    }
 }


### PR DESCRIPTION
[PHP 5.5 reached EOL](http://php.net/supported-versions.php) almost two years ago. We need to move forward guys.

Compared to previous versions of PHP we get:

* 'callable' as a typehint 
* Traits
* `$this` in closures
* Function array dereferencing (no need for transistional variables)
* Class member access on instantiation
* Generators
* `finally` keyword
* `empty()` for anything
* array and string dereferencing
* `::class`
* scalar expression in constants
* constant arrays
* Variadic functions and argument unpacking
* support for importing functions and constants in addition to classes
* default character set UTF-8
* `__debugInfo()`
* and so on
