### PR TITLE
Virtual file system with a Closure as a callback

### DIFF
--- a/src/Liquid/FileSystem/Virtual.php
+++ b/src/Liquid/FileSystem/Virtual.php
@@ -49,4 +49,13 @@ class Virtual implements FileSystem
 	public function readTemplateFile($templatePath) {
 		return call_user_func($this->callback, $templatePath);
 	}
+
+	public function __sleep() {
+		// we cannot serialize a closure
+		if ($this->callback instanceof \Closure) {
+			throw new LiquidException("Virtual file system with a Closure as a callback cannot be used with a serializing cache");
+		}
+
+		return array_keys(get_object_vars($this));
+	}
 }

--- a/tests/Liquid/DropTest.php
+++ b/tests/Liquid/DropTest.php
@@ -39,7 +39,7 @@ class CatchallDrop extends Drop
 class ProductDrop extends Drop
 {
 	public function top_sales() {
-		trigger_error('worked', E_USER_ERROR);
+		throw new \Exception("worked");
 	}
 
 	public function texts() {
@@ -62,7 +62,7 @@ class ProductDrop extends Drop
 class DropTest extends TestCase
 {
 	/**
-	 * @expectedException \PHPUnit_Framework_Error
+	 * @expectedException \Exception
 	 * @expectedExceptionMessage worked
 	 */
 	public function testProductDrop() {

--- a/tests/Liquid/Tag/TagExtendsTest.php
+++ b/tests/Liquid/Tag/TagExtendsTest.php
@@ -35,6 +35,11 @@ class TagExtendsTest extends TestCase
 		});
 	}
 
+	protected function tearDown() {
+		// PHP goes nuts unless we unset it
+		unset($this->fs);
+	}
+
 	public function testBasicExtends()
 	{
 		$template = new Template();

--- a/tests/Liquid/Tag/TagIncludeTest.php
+++ b/tests/Liquid/Tag/TagIncludeTest.php
@@ -32,6 +32,12 @@ class TagIncludeTest extends TestCase
 			}
 		});
 	}
+
+	protected function tearDown() {
+		// PHP goes nuts unless we unset it
+		unset($this->fs);
+	}
+
 	/**
 	 * @expectedException \Liquid\LiquidException
 	 */

--- a/tests/Liquid/VirtualFileSystemTest.php
+++ b/tests/Liquid/VirtualFileSystemTest.php
@@ -12,6 +12,7 @@
 namespace Liquid;
 
 use Liquid\FileSystem\Virtual;
+use Liquid\Cache\File;
 
 class VirtualFileSystemTest extends TestCase
 {
@@ -39,5 +40,20 @@ class VirtualFileSystemTest extends TestCase
 		$this->assertEquals('Contents of foo', $fs->readTemplateFile('foo'));
 		$this->assertEquals('Bar', $fs->readTemplateFile('bar'));
 		$this->assertEquals('', $fs->readTemplateFile('nothing'));
+	}
+
+	/**
+	 * @expectedException \Liquid\LiquidException
+	 * @expectedExceptionMessage cannot be used with a serializing cache
+	 */
+	public function testWithFileCache() {
+		$template = new Template();
+		$template->setFileSystem(new Virtual(function ($templatePath) {
+			return '';
+		}));
+		$template->setCache(new File(array(
+			'cache_dir' => __DIR__,
+		)));
+		$template->parse("Hello");
 	}
 }

--- a/tests/Liquid/VirtualFileSystemTest.php
+++ b/tests/Liquid/VirtualFileSystemTest.php
@@ -56,4 +56,19 @@ class VirtualFileSystemTest extends TestCase
 		)));
 		$template->parse("Hello");
 	}
+
+	public function virtualFileSystemCallback($templatePath) {
+		return 'OK';
+	}
+
+	public function testWithRegularCallback() {
+		$template = new Template();
+		$template->setFileSystem(new Virtual(array($this, 'virtualFileSystemCallback'), true));
+		$template->setCache(new File(array(
+			'cache_dir' => __DIR__.'/cache_dir/',
+		)));
+
+		$template->parse("Test: {% include 'hello' %}");
+		$this->assertEquals('Test: OK', $template->render());
+	}
 }

--- a/tests/Liquid/VirtualFileSystemTest.php
+++ b/tests/Liquid/VirtualFileSystemTest.php
@@ -24,7 +24,7 @@ class VirtualFileSystemTest extends TestCase
 		new Virtual('');
 	}
 
-	public function testFeadTemplateFile() {
+	public function testReadTemplateFile() {
 		$fs = new Virtual(function ($templatePath) {
 			if ($templatePath == 'foo') {
 				return "Contents of foo";


### PR DESCRIPTION
Virtual file system with a Closure as a callback cannot be used with a serializing cache: throw an error in this case.