### PR TITLE
Adopt PHP-CS-Fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,23 @@
+<?php
+
+$header = <<<'EOF'
+This file is part of the Liquid package.
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+@package Liquid
+EOF;
+
+return PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR2' => true,
+        'braces' => ['position_after_functions_and_oop_constructs' => 'same'],
+    ])
+    ->setIndent("\t")
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+        ->in(__DIR__)
+    )
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,9 @@ cache:
 install:
   - composer install --prefer-dist
 
+script:
+  - vendor/bin/phpunit --verbose || travis_terminate 1
+  - vendor/bin/php-cs-fixer --diff --dry-run --stop-on-violation --verbose fix
+
 after_success:
   - travis_retry php vendor/bin/coveralls

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "<6",
-        "satooshi/php-coveralls": "^1.0"
+        "satooshi/php-coveralls": "^1.0",
+        "friendsofphp/php-cs-fixer": "^2.6"
     },
     "autoload": {
         "psr-4": {

--- a/examples/advanced.php
+++ b/examples/advanced.php
@@ -30,4 +30,3 @@ echo $template->render([
 	'plain-html' => '<b>Your comment was:</b>',
 	'comment-with-xss' => '<script>alert();</script>',
 ]);
-

--- a/src/Liquid/AbstractBlock.php
+++ b/src/Liquid/AbstractBlock.php
@@ -14,8 +14,7 @@ namespace Liquid;
 /**
  * Base class for blocks.
  */
-class AbstractBlock extends AbstractTag
-{
+class AbstractBlock extends AbstractTag {
 	/**
 	 * @var AbstractTag[]
 	 */
@@ -75,10 +74,8 @@ class AbstractBlock extends AbstractTag
 				} else {
 					throw new LiquidException("Tag $token was not properly terminated"); // harry
 				}
-
 			} elseif ($variableStartRegexp->match($token)) {
 				$this->nodelist[] = $this->createVariable($token);
-
 			} elseif ($token != '') {
 				$this->nodelist[] = $token;
 			}

--- a/src/Liquid/AbstractTag.php
+++ b/src/Liquid/AbstractTag.php
@@ -14,8 +14,7 @@ namespace Liquid;
 /**
  * Base class for tags.
  */
-abstract class AbstractTag
-{
+abstract class AbstractTag {
 	/**
 	 * The markup for the tag
 	 *

--- a/src/Liquid/Cache.php
+++ b/src/Liquid/Cache.php
@@ -14,8 +14,7 @@ namespace Liquid;
 /**
  * Base class for Cache.
  */
-abstract class Cache
-{
+abstract class Cache {
 	/** @var int */
 	protected $expire = 3600;
 	/** @var string */

--- a/src/Liquid/Cache/Apc.php
+++ b/src/Liquid/Cache/Apc.php
@@ -19,8 +19,7 @@ use Liquid\LiquidException;
  *
  * @codeCoverageIgnore
  */
-class Apc extends Cache
-{
+class Apc extends Cache {
 	/**
 	 * Constructor.
 	 *
@@ -33,8 +32,9 @@ class Apc extends Cache
 	public function __construct(array $options = array()) {
 		parent::__construct($options);
 
-		if (!function_exists('apc_fetch'))
+		if (!function_exists('apc_fetch')) {
 			throw new LiquidException(get_class($this).' requires PHP apc extension or similar to be loaded.');
+		}
 	}
 
 	/**

--- a/src/Liquid/Cache/File.php
+++ b/src/Liquid/Cache/File.php
@@ -17,8 +17,7 @@ use Liquid\LiquidException;
 /**
  * Implements cache stored in files.
  */
-class File extends Cache
-{
+class File extends Cache {
 	/**
 	 * Constructor.
 	 *
@@ -42,8 +41,9 @@ class File extends Cache
 	 * {@inheritdoc}
 	 */
 	public function read($key, $unserialize = true) {
-		if (!$this->exists($key))
+		if (!$this->exists($key)) {
 			return false;
+		}
 
 		if ($unserialize) {
 			return unserialize(file_get_contents($this->path . $this->prefix . $key));

--- a/src/Liquid/Cache/Local.php
+++ b/src/Liquid/Cache/Local.php
@@ -16,8 +16,7 @@ use Liquid\Cache;
 /**
  * Implements cache with data stored in an embedded variable with no handling of expiration dates for simplicity
  */
-class Local extends Cache
-{
+class Local extends Cache {
 	private $cache = array();
 
 	/**

--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -14,8 +14,7 @@ namespace Liquid;
 /**
  * Context keeps the variable stack and resolves variables, as well as keywords.
  */
-class Context
-{
+class Context {
 	/**
 	 * Local scopes
 	 *
@@ -243,13 +242,13 @@ class Context
 	private function variable($key) {
 		// Support numeric and variable array indicies
 		if (preg_match("|\[[0-9]+\]|", $key)) {
-          $key = preg_replace("|\[([0-9]+)\]|", ".$1", $key);
-        } else if (preg_match("|\[[0-9a-z._]+\]|", $key, $matches)) {
-          $index = $this->get(str_replace(array("[","]"),"", $matches[0]));
-          if ( strlen($index) ) {
-            $key = preg_replace("|\[([0-9a-z._]+)\]|", ".$index", $key);
-          }
-        }
+			$key = preg_replace("|\[([0-9]+)\]|", ".$1", $key);
+		} elseif (preg_match("|\[[0-9a-z._]+\]|", $key, $matches)) {
+			$index = $this->get(str_replace(array("[","]"), "", $matches[0]));
+			if (strlen($index)) {
+				$key = preg_replace("|\[([0-9a-z._]+)\]|", ".$index", $key);
+			}
+		}
 
 		$parts = explode(Liquid::get('VARIABLE_ATTRIBUTE_SEPARATOR'), $key);
 

--- a/src/Liquid/CustomFilters.php
+++ b/src/Liquid/CustomFilters.php
@@ -14,8 +14,7 @@ namespace Liquid;
 /**
  * A selection of custom filters.
  */
-class CustomFilters
-{
+class CustomFilters {
 	
 	/**
 	 * Sort an array by key.
@@ -28,5 +27,4 @@ class CustomFilters
 		ksort($input);
 		return $input;
 	}
-
 }

--- a/src/Liquid/Decision.php
+++ b/src/Liquid/Decision.php
@@ -14,8 +14,7 @@ namespace Liquid;
 /**
  * Base class for blocks that make logical decisions.
  */
-class Decision extends AbstractBlock
-{
+class Decision extends AbstractBlock {
 	/**
 	 * The current left variable to compare
 	 *
@@ -95,11 +94,9 @@ class Decision extends AbstractBlock
 		if ($right == 'empty' && is_array($context->get($left))) {
 			$left = count($context->get($left));
 			$right = 0;
-
 		} elseif ($left == 'empty' && is_array($context->get($right))) {
 			$right = count($context->get($right));
 			$left = 0;
-
 		} else {
 			$left = $context->get($left);
 			$right = $context->get($right);

--- a/src/Liquid/Document.php
+++ b/src/Liquid/Document.php
@@ -17,8 +17,7 @@ use Liquid\Tag\TagExtends;
 /**
  * This class represents the entire template document.
  */
-class Document extends AbstractBlock
-{
+class Document extends AbstractBlock {
 	/**
 	 * Constructor.
 	 *

--- a/src/Liquid/Drop.php
+++ b/src/Liquid/Drop.php
@@ -32,8 +32,7 @@ namespace Liquid;
  * Your drop can either implement the methods sans any parameters or implement the beforeMethod(name) method which is a
  * catch all.
  */
-abstract class Drop
-{
+abstract class Drop {
 	/**
 	 * @var Context
 	 */

--- a/src/Liquid/FileSystem.php
+++ b/src/Liquid/FileSystem.php
@@ -19,8 +19,7 @@ namespace Liquid;
  *
  * You can add additional instance variables, arguments, or methods as needed.
  */
-interface FileSystem
-{
+interface FileSystem {
 	/**
 	 * Retrieve a template file.
 	 *

--- a/src/Liquid/FileSystem/Local.php
+++ b/src/Liquid/FileSystem/Local.php
@@ -22,8 +22,7 @@ use Liquid\Liquid;
  *
  * For security reasons, template paths are only allowed to contain letters, numbers, and underscore.
  */
-class Local implements FileSystem
-{
+class Local implements FileSystem {
 	/**
 	 * The root path
 	 *

--- a/src/Liquid/FileSystem/Virtual.php
+++ b/src/Liquid/FileSystem/Virtual.php
@@ -17,8 +17,7 @@ use Liquid\LiquidException;
 /**
  * This implements a virtual file system with actual code used to find files injected from outside thus achieving inversion of control.
  */
-class Virtual implements FileSystem
-{
+class Virtual implements FileSystem {
 	/**
 	 * @var callable
 	 */

--- a/src/Liquid/Filterbank.php
+++ b/src/Liquid/Filterbank.php
@@ -15,8 +15,7 @@ namespace Liquid;
  * The filter bank is where all registered filters are stored, and where filter invocation is handled
  * it supports a variety of different filter types; objects, class, and simple methods.
  */
-class Filterbank
-{
+class Filterbank {
 	/**
 	 * The registered filter objects
 	 *

--- a/src/Liquid/Liquid.php
+++ b/src/Liquid/Liquid.php
@@ -14,8 +14,7 @@ namespace Liquid;
 /**
  * Liquid for PHP.
  */
-class Liquid
-{
+class Liquid {
 	/**
 	 * We cannot make settings constants, because we cannot create compound
 	 * constants in PHP (before 5.6).

--- a/src/Liquid/LiquidException.php
+++ b/src/Liquid/LiquidException.php
@@ -14,6 +14,5 @@ namespace Liquid;
 /**
  * LiquidException class.
  */
-class LiquidException extends \Exception
-{
+class LiquidException extends \Exception {
 }

--- a/src/Liquid/LocalFileSystem.php
+++ b/src/Liquid/LocalFileSystem.php
@@ -14,4 +14,5 @@ namespace Liquid;
 /**
  * @deprecated Left for backward compatibility reasons. Use \Liquid\FileSystem\Local instead.
  */
-class LocalFileSystem extends \Liquid\FileSystem\Local {}
+class LocalFileSystem extends \Liquid\FileSystem\Local {
+}

--- a/src/Liquid/Regexp.php
+++ b/src/Liquid/Regexp.php
@@ -15,8 +15,7 @@ namespace Liquid;
  * A support class for regular expressions and
  * non liquid specific support classes and functions.
  */
-class Regexp
-{
+class Regexp {
 	/**
 	 * The regexp pattern
 	 *

--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -14,8 +14,7 @@ namespace Liquid;
 /**
  * A selection of standard filters.
  */
-class StandardFilters
-{
+class StandardFilters {
 	
 	/**
 	 * Add one string to another
@@ -38,10 +37,10 @@ class StandardFilters
 	 * @return string
 	 */
 	public static function capitalize($input) {
-		return preg_replace_callback("/(^|[^\p{L}'])([\p{Ll}])/u", function($matches) {
+		return preg_replace_callback("/(^|[^\p{L}'])([\p{Ll}])/u", function ($matches) {
 			return $matches[1] . ucfirst($matches[2]);
 		}, ucwords($input));
-	}	
+	}
 	
 
 	/**
@@ -67,12 +66,12 @@ class StandardFilters
 			$input = strtotime($input);
 		}
 
-		if ($format == 'r')
+		if ($format == 'r') {
 			return date($format, $input);
+		}
 
 		return strftime($format, $input);
-
-	}	
+	}
 	
 	
 	/**
@@ -163,7 +162,7 @@ class StandardFilters
 			return $input->current();
 		}
 		return is_array($input) ? reset($input) : $input;
-	}	
+	}
 	
 	
 	/**
@@ -173,7 +172,7 @@ class StandardFilters
 	 */
 	public static function floor($input) {
 		return (int) floor((float)$input);
-	}	
+	}
 	
 	
 	/**
@@ -209,13 +208,13 @@ class StandardFilters
 	public static function last($input) {
 		if ($input instanceof \Traversable) {
 			$last = null;
-			foreach ($input as $elem){
+			foreach ($input as $elem) {
 				$last = $elem;
 			}
 			return $last;
 		}
 		return is_array($input) ? end($input) : $input;
-	}	
+	}
 	
 
 	/**
@@ -225,7 +224,7 @@ class StandardFilters
 	 */
 	public static function lstrip($input) {
 		return ltrim($input);
-	}	
+	}
 	
 	
 	/**
@@ -287,10 +286,10 @@ class StandardFilters
 	 *
 	 * @return string
 	 */
-    public static function newline_to_br($input) {
-        return is_string($input) ? str_replace("\n", "<br />\n", $input) : $input;
-    }
-    	
+	public static function newline_to_br($input) {
+		return is_string($input) ? str_replace("\n", "<br />\n", $input) : $input;
+	}
+		
 
 	/**
 	 * addition
@@ -345,7 +344,7 @@ class StandardFilters
 		}
 
 		return $input;
-	}	
+	}
 	
 
 	/**
@@ -405,7 +404,7 @@ class StandardFilters
 	 */
 	public static function round($input, $n = 0) {
 		return round((float)$input, (int)$n);
-	}	
+	}
 	
 	
 	/**
@@ -490,7 +489,7 @@ class StandardFilters
 		} else {
 			$first = reset($input);
 			if ($first !== false && is_array($first) && array_key_exists($property, $first)) {
-				uasort($input, function($a, $b) use ($property) {
+				uasort($input, function ($a, $b) use ($property) {
 					if ($a[$property] == $b[$property]) {
 						return 0;
 					}
@@ -501,7 +500,7 @@ class StandardFilters
 		}
 
 		return $input;
-	}	
+	}
 	
 
 	/**
@@ -550,7 +549,7 @@ class StandardFilters
 		return is_string($input) ? str_replace(array(
 			"\n", "\r"
 		), '', $input) : $input;
-	}	
+	}
 	
 
 	/**
@@ -605,7 +604,7 @@ class StandardFilters
 		}
 
 		return $input;
-	}	
+	}
 	
 
 	/**

--- a/src/Liquid/Tag/TagAssign.php
+++ b/src/Liquid/Tag/TagAssign.php
@@ -26,8 +26,7 @@ use Liquid\Context;
  *     {% assign var = var %}
  *     {% assign var = "hello" | upcase %}
  */
-class TagAssign extends AbstractTag
-{
+class TagAssign extends AbstractTag {
 	/**
 	 * @var string The variable to assign from
 	 */

--- a/src/Liquid/Tag/TagBlock.php
+++ b/src/Liquid/Tag/TagBlock.php
@@ -23,8 +23,7 @@ use Liquid\Regexp;
  *
  *     {% block foo %} bar {% endblock %}
  */
-class TagBlock extends AbstractBlock
-{
+class TagBlock extends AbstractBlock {
 	/**
 	 * The variable to assign to
 	 *

--- a/src/Liquid/Tag/TagBreak.php
+++ b/src/Liquid/Tag/TagBreak.php
@@ -26,8 +26,7 @@ use Liquid\Context;
  *       {{ i }}
  *     {% endfor %}
  */
-class TagBreak extends AbstractTag
-{
+class TagBreak extends AbstractTag {
 	/**
 	 * Renders the tag
 	 *

--- a/src/Liquid/Tag/TagCapture.php
+++ b/src/Liquid/Tag/TagCapture.php
@@ -24,8 +24,7 @@ use Liquid\Regexp;
  *
  *     {% capture foo %} bar {% endcapture %}
  */
-class TagCapture extends AbstractBlock
-{
+class TagCapture extends AbstractBlock {
 	/**
 	 * The variable to assign to
 	 *

--- a/src/Liquid/Tag/TagCase.php
+++ b/src/Liquid/Tag/TagCase.php
@@ -25,8 +25,7 @@ use Liquid\Regexp;
  *
  *     {% case condition %}{% when foo %} foo {% else %} bar {% endcase %}
  */
-class TagCase extends Decision
-{
+class TagCase extends Decision {
 	/**
 	 * Stack of nodelists
 	 *
@@ -105,7 +104,6 @@ class TagCase extends Decision
 					$this->pushNodelist();
 					$this->right = $whenSyntaxRegexp->matches[0];
 					$this->nodelist = array();
-
 				} else {
 					throw new LiquidException("Syntax Error in tag 'case' - Valid when condition: when [condition]"); // harry
 				}

--- a/src/Liquid/Tag/TagComment.php
+++ b/src/Liquid/Tag/TagComment.php
@@ -21,8 +21,7 @@ use Liquid\Context;
  *
  *     {% comment %} This will be ignored {% endcomment %}
  */
-class TagComment extends AbstractBlock
-{
+class TagComment extends AbstractBlock {
 	/**
 	 * Renders the block
 	 *

--- a/src/Liquid/Tag/TagContinue.php
+++ b/src/Liquid/Tag/TagContinue.php
@@ -26,8 +26,7 @@ use Liquid\Context;
  *       {{ i }}
  *     {% endfor %}
  */
-class TagContinue extends AbstractTag
-{
+class TagContinue extends AbstractTag {
 	/**
 	 * Renders the tag
 	 *

--- a/src/Liquid/Tag/TagCycle.php
+++ b/src/Liquid/Tag/TagCycle.php
@@ -34,8 +34,7 @@ use Liquid\FileSystem;
  *     will return
  *     one one two two
  */
-class TagCycle extends AbstractTag
-{
+class TagCycle extends AbstractTag {
 	/**
 	 * @var string The name of the cycle; if none is given one is created using the value list
 	 */

--- a/src/Liquid/Tag/TagDecrement.php
+++ b/src/Liquid/Tag/TagDecrement.php
@@ -27,8 +27,7 @@ use Liquid\Regexp;
  *
  * @author Viorel Dram
  */
-class TagDecrement extends AbstractTag
-{
+class TagDecrement extends AbstractTag {
 	/**
 	 * Name of the variable to decrement
 	 *

--- a/src/Liquid/Tag/TagExtends.php
+++ b/src/Liquid/Tag/TagExtends.php
@@ -27,8 +27,7 @@ use Liquid\Template;
  *
  *     {% extends "base" %}
  */
-class TagExtends extends AbstractTag
-{
+class TagExtends extends AbstractTag {
 	/**
 	 * @var string The name of the template
 	 */
@@ -81,7 +80,7 @@ class TagExtends extends AbstractTag
 			if ($blockstartRegexp->match($token)) {
 				$name = $blockstartRegexp->matches[1];
 				$b[$name] = array();
-			} else if ($blockendRegexp->match($token)) {
+			} elseif ($blockendRegexp->match($token)) {
 				$name = null;
 			} else {
 				if ($name !== null) {
@@ -112,11 +111,12 @@ class TagExtends extends AbstractTag
 		$maintokens = Template::tokenize($source);
 
 		$eRegexp = new Regexp('/^' . Liquid::get('TAG_START') . '\s*extends (.*)?' . Liquid::get('TAG_END') . '$/');
-		foreach ($maintokens as $maintoken)
+		foreach ($maintokens as $maintoken) {
 			if ($eRegexp->match($maintoken)) {
 				$m = $eRegexp->matches[1];
 				break;
 			}
+		}
 
 		if (isset($m)) {
 			$rest = array_merge($maintokens, $tokens);
@@ -142,7 +142,6 @@ class TagExtends extends AbstractTag
 							array_push($rest, $item);
 						}
 					}
-
 				}
 				if (!$keep) {
 					array_push($rest, $maintokens[$i]);

--- a/src/Liquid/Tag/TagFor.php
+++ b/src/Liquid/Tag/TagFor.php
@@ -33,8 +33,7 @@ use Liquid\Regexp;
  *     {%for i in (1..variable)%} {{i}} {%endfor%}
  *
  */
-class TagFor extends AbstractBlock
-{
+class TagFor extends AbstractBlock {
 	/**
 	 * @var array The collection to loop over
 	 */
@@ -70,14 +69,11 @@ class TagFor extends AbstractBlock
 		$syntaxRegexp = new Regexp('/(\w+)\s+in\s+(' . Liquid::get('VARIABLE_NAME') . ')/');
 
 		if ($syntaxRegexp->match($markup)) {
-
 			$this->variableName = $syntaxRegexp->matches[1];
 			$this->collectionName = $syntaxRegexp->matches[2];
 			$this->name = $syntaxRegexp->matches[1] . '-' . $syntaxRegexp->matches[2];
 			$this->extractAttributes($markup);
-
 		} else {
-
 			$syntaxRegexp = new Regexp('/(\w+)\s+in\s+\((\d+|' . Liquid::get('VARIABLE_NAME') . ')\s*\.\.\s*(\d+|' . Liquid::get('VARIABLE_NAME') . ')\)/');
 			if ($syntaxRegexp->match($markup)) {
 				$this->type = 'digit';
@@ -100,12 +96,11 @@ class TagFor extends AbstractBlock
 	 * @return null|string
 	 */
 	public function render(Context $context) {
-
 		if (!isset($context->registers['for'])) {
 			$context->registers['for'] = array();
 		}
 
-		switch ($this->type){
+		switch ($this->type) {
 
 			case 'collection':
 
@@ -193,7 +188,6 @@ class TagFor extends AbstractBlock
 				$index = 0;
 				$length = $range[1] - $range[0];
 				for ($i=$range[0]; $i<=$range[1]; $i++) {
-
 					$context->set($this->variableName, $i);
 					$context->set('forloop', array(
 						'name'		=> $this->name,

--- a/src/Liquid/Tag/TagIf.php
+++ b/src/Liquid/Tag/TagIf.php
@@ -28,8 +28,7 @@ use Liquid\Regexp;
  *     will return:
  *     YES
  */
-class TagIf extends Decision
-{
+class TagIf extends Decision {
 	/**
 	 * Array holding the nodes to render for each logical block
 	 *
@@ -73,7 +72,6 @@ class TagIf extends Decision
 			$this->nodelistHolders[count($this->blocks) + 1] = array();
 
 			array_push($this->blocks, array($tag, $params, &$this->nodelist));
-
 		} else {
 			parent::unknownTag($tag, $params, $tokens);
 		}
@@ -137,7 +135,6 @@ class TagIf extends Decision
 							$display = ($display || $this->interpretCondition($conditions[$k + 1]['left'], $conditions[$k + 1]['right'], $conditions[$k + 1]['operator'], $context));
 						}
 					}
-
 				} else {
 					// If statement is a single condition
 					$display = $this->interpretCondition($conditions[0]['left'], $conditions[0]['right'], $conditions[0]['operator'], $context);

--- a/src/Liquid/Tag/TagIfchanged.php
+++ b/src/Liquid/Tag/TagIfchanged.php
@@ -18,8 +18,7 @@ use Liquid\FileSystem;
 /**
  * Quickly create a table from a collection
  */
-class TagIfchanged extends AbstractBlock
-{
+class TagIfchanged extends AbstractBlock {
 	/**
 	 * The last value
 	 *
@@ -56,6 +55,5 @@ class TagIfchanged extends AbstractBlock
 			$this->lastValue = $output;
 			return $this->lastValue;
 		}
-
 	}
 }

--- a/src/Liquid/Tag/TagInclude.php
+++ b/src/Liquid/Tag/TagInclude.php
@@ -38,8 +38,7 @@ use Liquid\Template;
  *     Will loop over all the values of bar, including the template foo, passing a variable called foo
  *     with each value of bar
  */
-class TagInclude extends AbstractTag
-{
+class TagInclude extends AbstractTag {
 	/**
 	 * @var string The name of the template
 	 */

--- a/src/Liquid/Tag/TagIncrement.php
+++ b/src/Liquid/Tag/TagIncrement.php
@@ -27,8 +27,7 @@ use Liquid\Regexp;
  *
  * @author Viorel Dram
  */
-class TagIncrement extends AbstractTag
-{
+class TagIncrement extends AbstractTag {
 	/**
 	 * Name of the variable to increment
 	 *

--- a/src/Liquid/Tag/TagPaginate.php
+++ b/src/Liquid/Tag/TagPaginate.php
@@ -31,8 +31,7 @@ use Liquid\Regexp;
  *
  */
 
-class TagPaginate extends AbstractBlock
-{
+class TagPaginate extends AbstractBlock {
 	/**
 	 * @var array The collection to paginate
 	 */
@@ -81,7 +80,6 @@ class TagPaginate extends AbstractBlock
 	 *
 	 */
 	public function __construct($markup, array &$tokens, FileSystem $fileSystem = null) {
-
 		parent::__construct($markup, $tokens, $fileSystem);
 
 		$syntax = new Regexp('/(' . Liquid::get('VARIABLE_NAME') . ')\s+by\s+(\w+)/');
@@ -93,7 +91,6 @@ class TagPaginate extends AbstractBlock
 		} else {
 			throw new LiquidException("Syntax Error - Valid syntax: paginate [collection] by [items]");
 		}
-
 	}
 
 	/**
@@ -105,8 +102,7 @@ class TagPaginate extends AbstractBlock
 	 *
 	 */
 	public function render(Context $context) {
-
-		$this->currentPage = ( is_numeric($context->get('page')) ) ? $context->get('page') : 1;
+		$this->currentPage = (is_numeric($context->get('page'))) ? $context->get('page') : 1;
 		$this->currentOffset = ($this->currentPage - 1) * $this->numberItems;
 		$this->collection = $context->get($this->collectionName);
 		if ($this->collection instanceof \Traversable) {
@@ -132,13 +128,12 @@ class TagPaginate extends AbstractBlock
 			'items' => $this->collectionSize
 		);
 
-		if ( $this->currentPage != 1 ) {
+		if ($this->currentPage != 1) {
 			$paginate['previous']['title'] = 'Previous';
 			$paginate['previous']['url'] = $this->currentUrl($context) . '?page=' . ($this->currentPage - 1);
-
 		}
 
-		if ( $this->currentPage != $this->totalPages ) {
+		if ($this->currentPage != $this->totalPages) {
 			$paginate['next']['title'] = 'Next';
 			$paginate['next']['url'] = $this->currentUrl($context) . '?page=' . ($this->currentPage + 1);
 		}
@@ -146,7 +141,6 @@ class TagPaginate extends AbstractBlock
 		$context->set('paginate', $paginate);
 
 		return parent::render($context);
-
 	}
 
 	/**
@@ -158,15 +152,14 @@ class TagPaginate extends AbstractBlock
 	 *
 	 */
 	public function currentUrl($context) {
-
 		$uri = explode('?', $context->get('REQUEST_URI'));
 
 		$url = 'http';
-		if ($context->get('HTTPS') == 'on') $url .= 's';
+		if ($context->get('HTTPS') == 'on') {
+			$url .= 's';
+		}
 		$url .= '://' . $context->get('HTTP_HOST') . reset($uri);
 
 		return $url;
-
 	}
-
 }

--- a/src/Liquid/Tag/TagRaw.php
+++ b/src/Liquid/Tag/TagRaw.php
@@ -25,8 +25,7 @@ use Liquid\Regexp;
  *     will return:
  *     {{ 5 | plus: 6 }} is equal to 11.
  */
-class TagRaw extends AbstractBlock
-{
+class TagRaw extends AbstractBlock {
 	/**
 	 * @param array $tokens
 	 */

--- a/src/Liquid/Tag/TagTablerow.php
+++ b/src/Liquid/Tag/TagTablerow.php
@@ -21,8 +21,7 @@ use Liquid\Regexp;
 /**
  * Quickly create a table from a collection
  */
-class TagTablerow extends AbstractBlock
-{
+class TagTablerow extends AbstractBlock {
 	/**
 	 * The variable name of the table tag
 	 *

--- a/src/Liquid/Tag/TagUnless.php
+++ b/src/Liquid/Tag/TagUnless.php
@@ -24,7 +24,7 @@ use Liquid\Context;
  *     NO
  */
 
-class TagUnless extends TagIf{
+class TagUnless extends TagIf {
 
 	/**
 	 * Replace first found key in $subject to value
@@ -35,7 +35,7 @@ class TagUnless extends TagIf{
 	 */
 	protected function strReplaceOne($replacer, $subject) {
 		$res = $subject;
-		foreach($replacer as $from => $to) {
+		foreach ($replacer as $from => $to) {
 			$res = str_ireplace($from, $to, $subject, $count);
 			if ($count > 0) {
 				break;
@@ -98,5 +98,4 @@ class TagUnless extends TagIf{
 		$res = parent::render($context);
 		return $res;
 	}
-
 }

--- a/src/Liquid/Template.php
+++ b/src/Liquid/Template.php
@@ -20,8 +20,7 @@ namespace Liquid;
  *     $tpl->parse(template_source);
  *     $tpl->render(array('foo'=>1, 'bar'=>2);
  */
-class Template
-{
+class Template {
 	/**
 	 * @var Document The root of the node tree
 	 */

--- a/src/Liquid/Variable.php
+++ b/src/Liquid/Variable.php
@@ -14,8 +14,7 @@ namespace Liquid;
 /**
  * Implements a template variable.
  */
-class Variable
-{
+class Variable {
 	/**
 	 * @var array The filters to execute on the variable
 	 */
@@ -61,7 +60,6 @@ class Variable
 
 				$this->filters[] = array($filtername, $matches);
 			}
-
 		} else {
 			$this->filters = array();
 		}

--- a/tests/Liquid/Cache/ApcTest.php
+++ b/tests/Liquid/Cache/ApcTest.php
@@ -14,8 +14,7 @@ namespace Liquid\Cache;
 use Liquid\TestCase;
 use \Liquid\Cache\Apc;
 
-class ApcTest extends TestCase
-{
+class ApcTest extends TestCase {
 	/** @var \Liquid\Cache\Apc */
 	protected $cache;
 
@@ -48,4 +47,3 @@ class ApcTest extends TestCase
 		$this->assertFalse($this->cache->read('test'));
 	}
 }
-

--- a/tests/Liquid/Cache/FileTest.php
+++ b/tests/Liquid/Cache/FileTest.php
@@ -13,8 +13,7 @@ namespace Liquid\Cache;
 
 use Liquid\TestCase;
 
-class FileTest extends TestCase
-{
+class FileTest extends TestCase {
 	/** @var \Liquid\Cache\File */
 	protected $cache;
 	protected $cacheDir;

--- a/tests/Liquid/Cache/LocalTest.php
+++ b/tests/Liquid/Cache/LocalTest.php
@@ -14,8 +14,7 @@ namespace Liquid\Cache;
 use Liquid\TestCase;
 use \Liquid\Cache\Local;
 
-class LocalTest extends TestCase
-{
+class LocalTest extends TestCase {
 	/** @var \Liquid\Cache\Local */
 	protected $cache;
 

--- a/tests/Liquid/ContextTest.php
+++ b/tests/Liquid/ContextTest.php
@@ -11,15 +11,13 @@
 
 namespace Liquid;
 
-class HundredCentes
-{
+class HundredCentes {
 	public function toLiquid() {
 		return 100;
 	}
 }
 
-class CentsDrop extends Drop
-{
+class CentsDrop extends Drop {
 	public function amount() {
 		return new HundredCentes();
 	}
@@ -51,8 +49,7 @@ class ToLiquidWrapper {
 	}
 }
 
-class NestedObject
-{
+class NestedObject {
 	public $property;
 	public $value = -1;
 
@@ -66,8 +63,7 @@ class NestedObject
 	}
 }
 
-class ToArrayObject
-{
+class ToArrayObject {
 	public $property;
 	public $value = -1;
 
@@ -81,8 +77,7 @@ class ToArrayObject
 	}
 }
 
-class GetSetObject
-{
+class GetSetObject {
 	public function field_exists($name) {
 		return $name == 'answer';
 	}
@@ -94,31 +89,27 @@ class GetSetObject
 	}
 }
 
-class HiFilter
-{
+class HiFilter {
 	public function hi($value) {
 		return $value . ' hi!';
 	}
 }
 
-class GlobalFilter
-{
+class GlobalFilter {
 	public function notice($value) {
 		return "Global $value";
 	}
 }
 
-class LocalFilter
-{
+class LocalFilter {
 	public function notice($value) {
 		return "Local $value";
 	}
 }
 
-class ContextTest extends TestCase
-{
+class ContextTest extends TestCase {
 	/** @var Context */
-	var $context;
+	public $context;
 
 	public function setup() {
 		parent::setUp();

--- a/tests/Liquid/CustomFiltersTest.php
+++ b/tests/Liquid/CustomFiltersTest.php
@@ -11,14 +11,13 @@
 
 namespace Liquid;
 
-class CustomFiltersTest extends TestCase
-{
+class CustomFiltersTest extends TestCase {
 	/**
 	 * The current context
 	 *
 	 * @var Context
 	 */
-	var $context;
+	public $context;
 
 	protected function setup() {
 		parent::setUp();
@@ -42,5 +41,4 @@ class CustomFiltersTest extends TestCase
 			$this->assertEquals($item[1], CustomFilters::sort_key($item[0]));
 		}
 	}
-
 }

--- a/tests/Liquid/DropTest.php
+++ b/tests/Liquid/DropTest.php
@@ -11,15 +11,13 @@
 
 namespace Liquid;
 
-class ContextDrop extends Drop
-{
+class ContextDrop extends Drop {
 	public function beforeMethod($method) {
 		return $this->context->get($method);
 	}
 }
 
-class TextDrop extends Drop
-{
+class TextDrop extends Drop {
 	public function get_array() {
 		return array('text1', 'text2');
 	}
@@ -29,15 +27,13 @@ class TextDrop extends Drop
 	}
 }
 
-class CatchallDrop extends Drop
-{
+class CatchallDrop extends Drop {
 	public function beforeMethod($method) {
 		return 'method: ' . $method;
 	}
 }
 
-class ProductDrop extends Drop
-{
+class ProductDrop extends Drop {
 	public function top_sales() {
 		throw new \Exception("worked");
 	}
@@ -63,8 +59,7 @@ class ProductDrop extends Drop
 	}
 }
 
-class DropTest extends TestCase
-{
+class DropTest extends TestCase {
 	/**
 	 * @expectedException \Exception
 	 * @expectedExceptionMessage worked
@@ -116,8 +111,7 @@ class DropTest extends TestCase
 		$this->assertEquals(' monkey ', $output);
 	}
 
-	public function testToString()
-	{
+	public function testToString() {
 		$this->assertEquals(ProductDrop::class, strval(new ProductDrop()));
 	}
 }

--- a/tests/Liquid/EscapeByDefaultTest.php
+++ b/tests/Liquid/EscapeByDefaultTest.php
@@ -11,8 +11,7 @@
 
 namespace Liquid;
 
-class EscapeByDefaultTest extends TestCase
-{
+class EscapeByDefaultTest extends TestCase {
 	const XSS = "<script>alert()</script>";
 	const XSS_FAILED = "&lt;script&gt;alert()&lt;/script&gt;";
 

--- a/tests/Liquid/FilterbankTest.php
+++ b/tests/Liquid/FilterbankTest.php
@@ -25,8 +25,7 @@ function functionFilter($value) {
 /**
  * Global filter class
  */
-class ClassFilter
-{
+class ClassFilter {
 	private $variable = 'not set';
 
 	public static function static_test() {
@@ -47,8 +46,7 @@ class ClassFilter
 
 namespace Liquid {
 
-class FilterbankTest extends TestCase
-{
+class FilterbankTest extends TestCase {
 	/** @var FilterBank */
 	private $filterBank;
 

--- a/tests/Liquid/LiquidTest.php
+++ b/tests/Liquid/LiquidTest.php
@@ -11,8 +11,7 @@
 
 namespace Liquid;
 
-class LiquidTest extends TestCase
-{
+class LiquidTest extends TestCase {
 	public function testGetNonExistingPropery() {
 		$this->assertNull(Liquid::get('no_such_value'));
 	}

--- a/tests/Liquid/LocalFileSystemTest.php
+++ b/tests/Liquid/LocalFileSystemTest.php
@@ -11,8 +11,7 @@
 
 namespace Liquid;
 
-class LocalFileSystemTest extends TestCase
-{
+class LocalFileSystemTest extends TestCase {
 	protected $root;
 
 	protected function setUp() {

--- a/tests/Liquid/OutputTest.php
+++ b/tests/Liquid/OutputTest.php
@@ -11,8 +11,7 @@
 
 namespace Liquid;
 
-class FunnyFilter
-{
+class FunnyFilter {
 	public function make_funny($input) {
 		return 'LOL';
 	}
@@ -38,8 +37,7 @@ class FunnyFilter
 	}
 }
 
-class OutputTest extends TestCase
-{
+class OutputTest extends TestCase {
 	protected $assigns = array();
 
 	protected function setup() {

--- a/tests/Liquid/ParsingQuirksTest.php
+++ b/tests/Liquid/ParsingQuirksTest.php
@@ -11,8 +11,7 @@
 
 namespace Liquid;
 
-class ParsingQuirksTest extends TestCase
-{
+class ParsingQuirksTest extends TestCase {
 	public function testErrorWithCss() {
 		$text = " div { font-weight: bold; } ";
 		$template = new Template();

--- a/tests/Liquid/RegexpTest.php
+++ b/tests/Liquid/RegexpTest.php
@@ -11,8 +11,7 @@
 
 namespace Liquid;
 
-class RegexpTest extends TestCase
-{
+class RegexpTest extends TestCase {
 	/** @var Regexp */
 	protected $regexp;
 

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -11,8 +11,7 @@
 
 namespace Liquid;
 
-class MoneyFilter
-{
+class MoneyFilter {
 	public function money($value) {
 		return sprintf(' %d$ ', $value);
 	}
@@ -22,15 +21,13 @@ class MoneyFilter
 	}
 }
 
-class CanadianMoneyFilter
-{
+class CanadianMoneyFilter {
 	public function money($value) {
 		return sprintf(' %d$ CAD ', $value);
 	}
 }
 
-class SizeClass
-{
+class SizeClass {
 	const SIZE = 42;
 
 	public function toLiquid() {
@@ -43,14 +40,13 @@ class SizeClass
 }
 
 
-class StandardFiltersTest extends TestCase
-{
+class StandardFiltersTest extends TestCase {
 	/**
 	 * The current context
 	 *
 	 * @var Context
 	 */
-	var $context;
+	public $context;
 
 	protected function setup() {
 		parent::setUp();
@@ -137,8 +133,7 @@ class StandardFiltersTest extends TestCase
 	}
 
 
-	public function testRaw()
-	{
+	public function testRaw() {
 		$data = array(
 			"Anything" => "Anything",
 			3 => 3,
@@ -511,27 +506,27 @@ class StandardFiltersTest extends TestCase
 		$this->assertEquals($expected, StandardFilters::sort(new \ArrayIterator($original), 'b'), '', 0, 10, true);
 	}
 
-/*
-	
-	I've commented this out as its not one of the Ruby Standard Filters
-	
-	public function testSortKey() {
-		$data = array(
-			array(
-				array(),
-				array(),
-			),
-			array(
-				array('b' => 1, 'c' => 5, 'a' => 3, 'z' => 4, 'h' => 2),
-				array('a' => 3, 'b' => 1, 'c' => 5, 'h' => 2, 'z' => 4),
-			),
-		);
+	/*
 
-		foreach ($data as $item) {
-			$this->assertEquals($item[1], StandardFilters::sort_key($item[0]));
+		I've commented this out as its not one of the Ruby Standard Filters
+
+		public function testSortKey() {
+			$data = array(
+				array(
+					array(),
+					array(),
+				),
+				array(
+					array('b' => 1, 'c' => 5, 'a' => 3, 'z' => 4, 'h' => 2),
+					array('a' => 3, 'b' => 1, 'c' => 5, 'h' => 2, 'z' => 4),
+				),
+			);
+
+			foreach ($data as $item) {
+				$this->assertEquals($item[1], StandardFilters::sort_key($item[0]));
+			}
 		}
-	}
-*/
+	*/
 
 	public function testDefault() {
 		$this->assertEquals('hello', StandardFilters::_default('', 'hello'));
@@ -602,7 +597,7 @@ class StandardFiltersTest extends TestCase
 			),
 			array(
 				array(
-					function() {
+					function () {
 						return 'from function ';
 					},
 					array(
@@ -618,7 +613,7 @@ class StandardFiltersTest extends TestCase
 			),
 			array(
 				new \ArrayIterator(array(
-					function() {
+					function () {
 						return 'from function ';
 					},
 					array(
@@ -835,9 +830,9 @@ class StandardFiltersTest extends TestCase
 				-1.2,
 			),
 			array(
-			    3.1,
-			    3.1,
-			    0
+				3.1,
+				3.1,
+				0
 			)
 		);
 
@@ -864,9 +859,9 @@ class StandardFiltersTest extends TestCase
 				4.05,
 			),
 			array(
-			      7.5,
-			      0,
-			      0
+				  7.5,
+				  0,
+				  0
 			)
 		);
 

--- a/tests/Liquid/Tag/NoTransformTest.php
+++ b/tests/Liquid/Tag/NoTransformTest.php
@@ -13,11 +13,12 @@ namespace Liquid\Tag;
 
 use Liquid\TestCase;
 
-class NoTransformTest extends TestCase
-{
+class NoTransformTest extends TestCase {
 	public function testNoTransform() {
-		$this->assertTemplateResult('this text should come out of the template without change...',
-			'this text should come out of the template without change...');
+		$this->assertTemplateResult(
+			'this text should come out of the template without change...',
+			'this text should come out of the template without change...'
+		);
 
 		$this->assertTemplateResult('blah', 'blah');
 		$this->assertTemplateResult('<blah>', '<blah>');

--- a/tests/Liquid/Tag/TagAssignTest.php
+++ b/tests/Liquid/Tag/TagAssignTest.php
@@ -18,8 +18,7 @@ use Liquid\Template;
  * Basic tests for the assignment of one variable to another. This also tests the
  * assignment of filtered values to another variable.
  */
-class TagAssignTest extends TestCase
-{
+class TagAssignTest extends TestCase {
 	/**
 	 * Tests the normal behavior of throwing an exception when the assignment is incorrect
 	 *

--- a/tests/Liquid/Tag/TagBlockTest.php
+++ b/tests/Liquid/Tag/TagBlockTest.php
@@ -13,8 +13,7 @@ namespace Liquid\Tag;
 
 use Liquid\TestCase;
 
-class TagBlockTest extends TestCase
-{
+class TagBlockTest extends TestCase {
 	/**
 	 * @expectedException \Liquid\LiquidException
 	 */

--- a/tests/Liquid/Tag/TagBreakTest.php
+++ b/tests/Liquid/Tag/TagBreakTest.php
@@ -13,32 +13,34 @@ namespace Liquid\Tag;
 
 use Liquid\TestCase;
 
-class TagBreakTest extends TestCase
-{
-    public function testFor() {
-        $this->assertTemplateResult(' ', '{%for item in array%} {%break%} yo {%endfor%}', array('array' => array(1, 2, 3, 4)));
-        $this->assertTemplateResult(' yo ', '{%for item in array%} yo {%break%} {%endfor%}', array('array' => array(1, 2, 3, 4)));
-        $this->assertTemplateResult('  1   2   ', '{%for item in array%} {%if item == 3%} {%break%} {%endif%} {{ item }} {%endfor%}', array('array' => array(1, 2, 3, 4)));
-    }
+class TagBreakTest extends TestCase {
+	public function testFor() {
+		$this->assertTemplateResult(' ', '{%for item in array%} {%break%} yo {%endfor%}', array('array' => array(1, 2, 3, 4)));
+		$this->assertTemplateResult(' yo ', '{%for item in array%} yo {%break%} {%endfor%}', array('array' => array(1, 2, 3, 4)));
+		$this->assertTemplateResult('  1   2   ', '{%for item in array%} {%if item == 3%} {%break%} {%endif%} {{ item }} {%endfor%}', array('array' => array(1, 2, 3, 4)));
+	}
 
-    public function testRange() {
-        $this->assertTemplateResult(' ', '{%for item in (3..6)%} {%break%} yo {%endfor%}');
-        $this->assertTemplateResult(' yo ', '{%for item in (3..6)%} yo {%break%} {%endfor%}');
-        $this->assertTemplateResult('  3   4   ', '{%for item in (3..6)%} {%if item == 5%} {%break%} {%endif%} {{ item }} {%endfor%}');
-    }
+	public function testRange() {
+		$this->assertTemplateResult(' ', '{%for item in (3..6)%} {%break%} yo {%endfor%}');
+		$this->assertTemplateResult(' yo ', '{%for item in (3..6)%} yo {%break%} {%endfor%}');
+		$this->assertTemplateResult('  3   4   ', '{%for item in (3..6)%} {%if item == 5%} {%break%} {%endif%} {{ item }} {%endfor%}');
+	}
 
-    public function testTablerow() {
-        $this->assertTemplateResult(
-            "<tr class=\"row1\">\n</tr>\n",
-            '{%tablerow item in array%} {%break%} yo {%endtablerow%}',
-            array('array' => array(1, 2, 3, 4)));
-        $this->assertTemplateResult(
-            "<tr class=\"row1\">\n<td class=\"col1\"> yo </td></tr>\n",
-            '{%tablerow item in array%} yo {%break%} {%endtablerow%}',
-            array('array' => array(1, 2, 3, 4)));
-        $this->assertTemplateResult(
-            "<tr class=\"row1\">\n<td class=\"col1\">  1 </td><td class=\"col2\">  2 </td></tr>\n",
-            '{%tablerow item in array%} {%if item == 3%} {%break%} {%endif%} {{ item }} {%endtablerow%}',
-            array('array' => array(1, 2, 3, 4)));
-    }
+	public function testTablerow() {
+		$this->assertTemplateResult(
+			"<tr class=\"row1\">\n</tr>\n",
+			'{%tablerow item in array%} {%break%} yo {%endtablerow%}',
+			array('array' => array(1, 2, 3, 4))
+		);
+		$this->assertTemplateResult(
+			"<tr class=\"row1\">\n<td class=\"col1\"> yo </td></tr>\n",
+			'{%tablerow item in array%} yo {%break%} {%endtablerow%}',
+			array('array' => array(1, 2, 3, 4))
+		);
+		$this->assertTemplateResult(
+			"<tr class=\"row1\">\n<td class=\"col1\">  1 </td><td class=\"col2\">  2 </td></tr>\n",
+			'{%tablerow item in array%} {%if item == 3%} {%break%} {%endif%} {{ item }} {%endtablerow%}',
+			array('array' => array(1, 2, 3, 4))
+		);
+	}
 }

--- a/tests/Liquid/Tag/TagCaptureTest.php
+++ b/tests/Liquid/Tag/TagCaptureTest.php
@@ -14,8 +14,7 @@ namespace Liquid\Tag;
 use Liquid\TestCase;
 use Liquid\Template;
 
-class TagCaptureTest extends TestCase
-{
+class TagCaptureTest extends TestCase {
 	/**
 	 * @expectedException \Liquid\LiquidException
 	 */

--- a/tests/Liquid/Tag/TagCaseTest.php
+++ b/tests/Liquid/Tag/TagCaseTest.php
@@ -13,22 +13,19 @@ namespace Liquid\Tag;
 
 use Liquid\TestCase;
 
-class Stringable
-{
+class Stringable {
 	public function __toString() {
 		return "100";
 	}
 }
 
-class HasToLiquid
-{
+class HasToLiquid {
 	public function toLiquid() {
 		return "100";
 	}
 }
 
-class TagCaseTest extends TestCase
-{
+class TagCaseTest extends TestCase {
 	public function testCase() {
 		$assigns = array('condition' => 2);
 		$this->assertTemplateResult(' its 2 ', '{% case condition %}{% when 1 %} its 1 {% when 2 %} its 2 {% endcase %}', $assigns);

--- a/tests/Liquid/Tag/TagCommentTest.php
+++ b/tests/Liquid/Tag/TagCommentTest.php
@@ -13,11 +13,12 @@ namespace Liquid\Tag;
 
 use Liquid\TestCase;
 
-class TagCommentTest extends TestCase
-{
+class TagCommentTest extends TestCase {
 	public function testHasABlockWhichDoesNothing() {
-		$this->assertTemplateResult("the comment block should be removed  .. right?",
-			"the comment block should be removed {%comment%} be gone.. {%endcomment%} .. right?");
+		$this->assertTemplateResult(
+			"the comment block should be removed  .. right?",
+			"the comment block should be removed {%comment%} be gone.. {%endcomment%} .. right?"
+		);
 
 		$this->assertTemplateResult('', '{%comment%}{%endcomment%}');
 		$this->assertTemplateResult('', '{%comment%}{% endcomment %}');

--- a/tests/Liquid/Tag/TagContinueTest.php
+++ b/tests/Liquid/Tag/TagContinueTest.php
@@ -13,8 +13,7 @@ namespace Liquid\Tag;
 
 use Liquid\TestCase;
 
-class TagContinueTest extends TestCase
-{
+class TagContinueTest extends TestCase {
 	public function testFor() {
 		$this->assertTemplateResult('    ', '{%for item in array%} {%continue%} yo {%endfor%}', array('array' => array(1, 2, 3, 4)));
 		$this->assertTemplateResult(' yo  yo  yo  yo ', '{%for item in array%} yo {%continue%} {%endfor%}', array('array' => array(1, 2, 3, 4)));
@@ -31,14 +30,17 @@ class TagContinueTest extends TestCase
 		$this->assertTemplateResult(
 			"<tr class=\"row1\">\n</tr>\n",
 			'{%tablerow item in array%} {%continue%} yo {%endtablerow%}',
-			array('array' => array(1, 2, 3, 4)));
+			array('array' => array(1, 2, 3, 4))
+		);
 		$this->assertTemplateResult(
 			"<tr class=\"row1\">\n<td class=\"col1\"> yo </td><td class=\"col2\"> yo </td><td class=\"col3\"> yo </td><td class=\"col4\"> yo </td></tr>\n",
 			'{%tablerow item in array%} yo {%continue%} {%endtablerow%}',
-			array('array' => array(1, 2, 3, 4)));
+			array('array' => array(1, 2, 3, 4))
+		);
 		$this->assertTemplateResult(
 			"<tr class=\"row1\">\n<td class=\"col1\">  1 </td><td class=\"col2\">  2 </td><td class=\"col3\">  4 </td></tr>\n",
 			'{%tablerow item in array%} {%if item == 3%} {%continue%} {%endif%} {{ item }} {%endtablerow%}',
-			array('array' => array(1, 2, 3, 4)));
+			array('array' => array(1, 2, 3, 4))
+		);
 	}
 }

--- a/tests/Liquid/Tag/TagCycleTest.php
+++ b/tests/Liquid/Tag/TagCycleTest.php
@@ -14,8 +14,7 @@ namespace Liquid\Tag;
 use Liquid\TestCase;
 use Liquid\Template;
 
-class TagCycleTest extends TestCase
-{
+class TagCycleTest extends TestCase {
 	/**
 	 * @expectedException \Liquid\LiquidException
 	 */

--- a/tests/Liquid/Tag/TagDecrementTest.php
+++ b/tests/Liquid/Tag/TagDecrementTest.php
@@ -13,8 +13,7 @@ namespace Liquid\Tag;
 
 use Liquid\TestCase;
 
-class TagDecrementTest extends TestCase
-{
+class TagDecrementTest extends TestCase {
 	/**
 	 * @expectedException \Liquid\LiquidException
 	 */

--- a/tests/Liquid/Tag/TagExtendsTest.php
+++ b/tests/Liquid/Tag/TagExtendsTest.php
@@ -19,8 +19,7 @@ use Liquid\FileSystem\Virtual;
 /**
  * @see TagExtends
  */
-class TagExtendsTest extends TestCase
-{
+class TagExtendsTest extends TestCase {
 	private $fs;
 
 	protected function setUp() {
@@ -40,8 +39,7 @@ class TagExtendsTest extends TestCase
 		unset($this->fs);
 	}
 
-	public function testBasicExtends()
-	{
+	public function testBasicExtends() {
 		$template = new Template();
 		$template->setFileSystem($this->fs);
 		$template->parse("{% extends 'base' %}{% block content %}{{ hello }}{% endblock %}");
@@ -49,8 +47,7 @@ class TagExtendsTest extends TestCase
 		$this->assertEquals("Hello!", $output);
 	}
 
-	public function testDefaultContentExtends()
-	{
+	public function testDefaultContentExtends() {
 		$template = new Template();
 		$template->setFileSystem($this->fs);
 		$template->parse("{% block content %}{{ hello }}{% endblock %}\n{% extends 'sub-base' %}");
@@ -58,8 +55,7 @@ class TagExtendsTest extends TestCase
 		$this->assertEquals("Hello!\n Boo! ", $output);
 	}
 
-	public function testDeepExtends()
-	{
+	public function testDeepExtends() {
 		$template = new Template();
 		$template->setFileSystem($this->fs);
 		$template->parse('{% extends "sub-base" %}{% block content %}{{ hello }}{% endblock %}{% block footer %} I am a footer.{% endblock %}');

--- a/tests/Liquid/Tag/TagForTest.php
+++ b/tests/Liquid/Tag/TagForTest.php
@@ -14,8 +14,7 @@ namespace Liquid\Tag;
 use Liquid\TestCase;
 use Liquid\Template;
 
-class TagForTest extends TestCase
-{
+class TagForTest extends TestCase {
 	/**
 	 * @expectedException \Liquid\LiquidException
 	 */

--- a/tests/Liquid/Tag/TagIfTest.php
+++ b/tests/Liquid/Tag/TagIfTest.php
@@ -13,8 +13,7 @@ namespace Liquid\Tag;
 
 use Liquid\TestCase;
 
-class TagIfTest extends TestCase
-{
+class TagIfTest extends TestCase {
 	public function testTrueEqlTrue() {
 		$text = " {% if true == true %} true {% else %} false {% endif %} ";
 		$expected = "  true  ";
@@ -238,6 +237,4 @@ class TagIfTest extends TestCase
 	public function testSyntaxErrorUnknown() {
 		$this->assertTemplateResult('', '{% unknown-tag %}');
 	}
-
-
 }

--- a/tests/Liquid/Tag/TagIfchangedTest.php
+++ b/tests/Liquid/Tag/TagIfchangedTest.php
@@ -13,8 +13,7 @@ namespace Liquid\Tag;
 
 use Liquid\TestCase;
 
-class TagIfchangedTest extends TestCase
-{
+class TagIfchangedTest extends TestCase {
 	public function testWorks() {
 		$text = "{% for i in array %}{% ifchanged %} {{ i }} {% endifchanged %}{% endfor %}";
 		$expected = " 1  2  3 ";
@@ -26,5 +25,4 @@ class TagIfchangedTest extends TestCase
 		$expected = " 1  2  1 ";
 		$this->assertTemplateResult($expected, $text, array('array' => array(1, 2, 2, 1)));
 	}
-
 }

--- a/tests/Liquid/Tag/TagIncludeTest.php
+++ b/tests/Liquid/Tag/TagIncludeTest.php
@@ -18,8 +18,7 @@ use Liquid\Cache\Local;
 use Liquid\FileSystem\Virtual;
 use Liquid\TestFileSystem;
 
-class TagIncludeTest extends TestCase
-{
+class TagIncludeTest extends TestCase {
 	private $fs;
 
 	protected function setUp() {
@@ -130,7 +129,6 @@ class TagIncludeTest extends TestCase
 	 * @expectedExceptionMessage Use index operator
 	 */
 	public function testIncludePassArrayWithoutIndex() {
-
 		$template = new Template();
 		$template->setFileSystem(TestFileSystem::fromArray(array(
 			'inner' => "[{{ other }}]",
@@ -142,7 +140,6 @@ class TagIncludeTest extends TestCase
 	}
 
 	public function testIncludePassArrayWithIndex() {
-
 		$template = new Template();
 		$template->setFileSystem(TestFileSystem::fromArray(array(
 			'inner' => "[{{ other[0] }}]",

--- a/tests/Liquid/Tag/TagIncrementTest.php
+++ b/tests/Liquid/Tag/TagIncrementTest.php
@@ -13,8 +13,7 @@ namespace Liquid\Tag;
 
 use Liquid\TestCase;
 
-class TagIncrementTest extends TestCase
-{
+class TagIncrementTest extends TestCase {
 	/**
 	 * @expectedException \Liquid\LiquidException
 	 */

--- a/tests/Liquid/Tag/TagPaginateTest.php
+++ b/tests/Liquid/Tag/TagPaginateTest.php
@@ -21,15 +21,15 @@ class TagPaginateTest extends TestCase {
 	}
 
 	public function testVariables() {
-		$text = " {% paginate search.products by 3 %}{{ paginate.page_size }} {{ paginate.current_page }} {{ paginate.current_offset }} {{ paginate.pages }} {{ paginate.items }} {% endpaginate %}";
-		$expected = " 3 1 0 2 5 ";
+		$text = " {% paginate search.products by 3 %}{{ paginate.page_size }} {{ paginate.current_page }} {{ paginate.current_offset }} {{ paginate.pages }} {{ paginate.items }} {{ paginate.next.url }}{% endpaginate %}";
+		$expected = " 3 1 0 2 5 http://?page=2";
 		$this->assertTemplateResult($expected, $text, array('search' => array('products' => new \ArrayIterator(array(array('id' => 1), array('id' => 2), array('id' => 3), array('id' => 4), array('id' => 5))))));
 	}
 
 	public function testNextPage() {
-		$text = "{% paginate products by 1 %}{% for product in products %} {{ product.id }} {% endfor %}{% endpaginate %}";
-		$expected = " 2 ";
-		$this->assertTemplateResult($expected, $text, array('page' => 2,'products' => array(array('id' => 1), array('id' => 2), array('id' => 3), array('id' => 4), array('id' => 5))));
+		$text = '{% paginate products by 1 %}{% for product in products %} {{ product.id }} {% endfor %}<a href="{{ paginate.next.url }}">{{ paginate.next.title }}</a>{% endpaginate %}';
+		$expected = ' 2 <a href="https://example.com/products?page=3">Next</a>';
+		$this->assertTemplateResult($expected, $text, array('HTTP_HOST' => 'example.com', 'REQUEST_URI' => '/products', 'HTTPS' => 'on', 'page' => 2,'products' => array(array('id' => 1), array('id' => 2), array('id' => 3), array('id' => 4), array('id' => 5))));
 	}
 
 	/**

--- a/tests/Liquid/Tag/TagPaginateTest.php
+++ b/tests/Liquid/Tag/TagPaginateTest.php
@@ -13,8 +13,7 @@ namespace Liquid\Tag;
 
 use Liquid\TestCase;
 
-class TagPaginateTest extends TestCase
-{
+class TagPaginateTest extends TestCase {
 	public function testWorks() {
 		$text = "{% paginate products by 3 %}{% for product in products %} {{ product.id }} {% endfor %}{% endpaginate %}";
 		$expected = " 1  2  3 ";
@@ -27,8 +26,7 @@ class TagPaginateTest extends TestCase
 		$this->assertTemplateResult($expected, $text, array('search' => array('products' => new \ArrayIterator(array(array('id' => 1), array('id' => 2), array('id' => 3), array('id' => 4), array('id' => 5))))));
 	}
 
-	public function testNextPage()
-	{
+	public function testNextPage() {
 		$text = "{% paginate products by 1 %}{% for product in products %} {{ product.id }} {% endfor %}{% endpaginate %}";
 		$expected = " 2 ";
 		$this->assertTemplateResult($expected, $text, array('page' => 2,'products' => array(array('id' => 1), array('id' => 2), array('id' => 3), array('id' => 4), array('id' => 5))));

--- a/tests/Liquid/Tag/TagRawTest.php
+++ b/tests/Liquid/Tag/TagRawTest.php
@@ -13,12 +13,12 @@ namespace Liquid\Tag;
 
 use Liquid\TestCase;
 
-class TagRawTest extends TestCase
-{
+class TagRawTest extends TestCase {
 	public function testRaw() {
 		$this->assertTemplateResult(
 			'{{ y | plus: x }}{{{hello}}} is equal to 11.',
-			'{% raw %}{{ y | plus: x }}{{{hello}}}{% endraw %} is equal to 11.', array('x' => 5, 'y' => 6)
+			'{% raw %}{{ y | plus: x }}{{{hello}}}{% endraw %} is equal to 11.',
+			array('x' => 5, 'y' => 6)
 		);
 
 		$this->assertTemplateResult('', '{% raw %}{% endraw %}');

--- a/tests/Liquid/Tag/TagTablerowTest.php
+++ b/tests/Liquid/Tag/TagTablerowTest.php
@@ -13,13 +13,13 @@ namespace Liquid\Tag;
 
 use Liquid\TestCase;
 
-class TagTablerowTest extends TestCase
-{
+class TagTablerowTest extends TestCase {
 	public function testTablerow() {
 		$this->assertTemplateResult(
 			'<tr class="row1">'."\n".'<td class="col1"> yo </td><td class="col2"> yo </td><td class="col3"> yo </td><td class="col4"> yo </td></tr>'."\n",
 			'{% tablerow item in array %} yo {% endtablerow %}',
-			array('array' => array(1, 2, 3, 4)));
+			array('array' => array(1, 2, 3, 4))
+		);
 
 		$this->assertTemplateResult(
 			'<tr class="row1">
@@ -28,31 +28,33 @@ class TagTablerowTest extends TestCase
 <td class="col1"> item 2 </td></tr>
 ',
 			'{% tablerow item in array cols:1 %} item {{ item }} {% endtablerow %}',
-			array('array' => array(1, 2)));
+			array('array' => array(1, 2))
+		);
 
 		$this->assertTemplateResult(
 			'<tr class="row1">'."\n".'<td class="col1"> 2 </td><td class="col2"> 3 </td></tr>'."\n",
 			'{% tablerow item in array limit:2 offset:1 %} {{ item }} {% endtablerow %}',
-			array('array' => array(1, 2, 3, 4)));
+			array('array' => array(1, 2, 3, 4))
+		);
 
 		$this->assertTemplateResult(
 			'<tr class="row1">'."\n".'<td class="col1"> yo </td><td class="col2"> yo </td></tr>'."\n",
 			'{%tablerow item in array%} yo {%endtablerow%}',
-			array('array' => new \ArrayIterator(array(1, 2))));
+			array('array' => new \ArrayIterator(array(1, 2)))
+		);
 	}
 
 	/**
 	 * @expectedException \Liquid\LiquidException
 	 */
 	public function testInvalidSyntax() {
-		$this->assertTemplateResult('',	'{%tablerow item array%} yo {%endtablerow%}', array());
+		$this->assertTemplateResult('', '{%tablerow item array%} yo {%endtablerow%}', array());
 	}
 
 	/**
 	 * @expectedException \Liquid\LiquidException
 	 */
 	public function testNotArray() {
-		$this->assertTemplateResult('',	'{%tablerow item in array%} yo {%endtablerow%}', array('array' => true));
+		$this->assertTemplateResult('', '{%tablerow item in array%} yo {%endtablerow%}', array('array' => true));
 	}
-
 }

--- a/tests/Liquid/Tag/TagUnlessTest.php
+++ b/tests/Liquid/Tag/TagUnlessTest.php
@@ -13,8 +13,7 @@ namespace Liquid\Tag;
 
 use Liquid\TestCase;
 
-class TagUnlessTest extends TestCase
-{
+class TagUnlessTest extends TestCase {
 	public function testTrueEqlTrue() {
 		$text = " {% unless true == true %} true {% else %} false {% endunless %} ";
 		$expected = "  false  ";

--- a/tests/Liquid/TemplateTest.php
+++ b/tests/Liquid/TemplateTest.php
@@ -11,8 +11,7 @@
 
 namespace Liquid;
 
-class TemplateTest extends TestCase
-{
+class TemplateTest extends TestCase {
 	const CACHE_DIR = 'cache_dir';
 
 	/** @var string full path to cache dir  */

--- a/tests/Liquid/TestCase.php
+++ b/tests/Liquid/TestCase.php
@@ -11,8 +11,7 @@
 
 namespace Liquid;
 
-class TestCase extends \PHPUnit_Framework_TestCase
-{
+class TestCase extends \PHPUnit_Framework_TestCase {
 	const TEMPLATES_DIR = 'templates';
 
 	/**

--- a/tests/Liquid/TestFileSystem.php
+++ b/tests/Liquid/TestFileSystem.php
@@ -13,11 +13,9 @@ namespace Liquid;
 
 use Liquid\FileSystem\Virtual;
 
-class TestFileSystem extends Virtual
-{
+class TestFileSystem extends Virtual {
 	/** @return TestFileSystem */
-	public static function fromArray($array)
-	{
+	public static function fromArray($array) {
 		return new static(function ($path) use ($array) {
 			if (isset($array[$path])) {
 				return $array[$path];

--- a/tests/Liquid/VariableResolutionTest.php
+++ b/tests/Liquid/VariableResolutionTest.php
@@ -11,8 +11,7 @@
 
 namespace Liquid;
 
-class VariableResolutionTest extends TestCase
-{
+class VariableResolutionTest extends TestCase {
 	public function testSimpleVariable() {
 		$template = new Template();
 		$template->parse("{{test}}");

--- a/tests/Liquid/VariableTest.php
+++ b/tests/Liquid/VariableTest.php
@@ -11,8 +11,7 @@
 
 namespace Liquid;
 
-class VariableTest extends TestCase
-{
+class VariableTest extends TestCase {
 	public function testVariable() {
 		$var = new Variable('hello');
 		$this->assertEquals('hello', $var->getName());
@@ -106,4 +105,3 @@ class VariableTest extends TestCase
 		$this->assertEquals('test.test', $var->getName());
 	}
 }
-

--- a/tests/Liquid/VirtualFileSystemTest.php
+++ b/tests/Liquid/VirtualFileSystemTest.php
@@ -14,8 +14,7 @@ namespace Liquid;
 use Liquid\FileSystem\Virtual;
 use Liquid\Cache\File;
 
-class VirtualFileSystemTest extends TestCase
-{
+class VirtualFileSystemTest extends TestCase {
 	/**
 	 * @expectedException \Liquid\LiquidException
 	 * @expectedExceptionMessage Not a callback


### PR DESCRIPTION
Adopt PHP-CS-Fixer with closest possible config to the currently used coding standard.

We can't have both braces on the next line after classes, and on the same for functions. If we only would have to change braces by classes, that would be least possible change in terms of lines changed.