### PR TITLE
Allow use of unquoted template names

### DIFF
--- a/src/Liquid/Tag/TagInclude.php
+++ b/src/Liquid/Tag/TagInclude.php
@@ -76,11 +76,17 @@ class TagInclude extends AbstractTag
 	 */
 	public function __construct($markup, array &$tokens, FileSystem $fileSystem = null)
 	{
-		$regex = new Regexp('/("[^"]+"|\'[^\']+\')(\s+(with|for)\s+(' . Liquid::get('QUOTED_FRAGMENT') . '+))?/');
+		$regex = new Regexp('/("[^"]+"|\'[^\']+\'|[^\'"\s]+)(\s+(with|for)\s+(' . Liquid::get('QUOTED_FRAGMENT') . '+))?/');
 
 		if ($regex->match($markup)) {
-			$this->templateName = substr($regex->matches[1], 1, strlen($regex->matches[1]) - 2);
-
+			$unquoted = (strpos($regex->matches[1], '"') === false && strpos($regex->matches[1], "'") === false);
+			$start = 1;
+			$len = strlen($regex->matches[1]) - 2;
+			if ($unquoted) {
+				$start = 0;
+				$len = strlen($regex->matches[1]);
+			}
+			$this->templateName = substr($regex->matches[1], $start, $len);
 			if (isset($regex->matches[1])) {
 				$this->collection = (isset($regex->matches[3])) ? ($regex->matches[3] == "for") : null;
 				$this->variable = (isset($regex->matches[4])) ? $regex->matches[4] : null;

--- a/tests/Liquid/Tag/TagIncludeTest.php
+++ b/tests/Liquid/Tag/TagIncludeTest.php
@@ -48,15 +48,6 @@ class TagIncludeTest extends TestCase
 	/**
 	 * @expectedException \Liquid\LiquidException
 	 */
-	public function testInvalidSyntaxNotQuotedTemplateName()
-	{
-		$template = new Template();
-		$template->parse("{% include hello %}");
-	}
-
-	/**
-	 * @expectedException \Liquid\LiquidException
-	 */
 	public function testInvalidSyntaxInvalidKeyword()
 	{
 		$template = new Template();
@@ -178,5 +169,20 @@ class TagIncludeTest extends TestCase
 
 		$output = $template->render(array("var" => (object) array('a' => 'b')));
 		$this->assertEquals("([b])", $output);
+	}
+
+
+	public function testIncludeWithoutQuotes()
+	{
+		$template = new Template();
+		$template->setFileSystem(TestFileSystem::fromArray(array(
+			'inner' => "[{{ other }}]",
+			'example' => "{%include inner other:var %} ({{var}})",
+		)));
+
+		$template->parse("{% include example other:var %}");
+
+		$output = $template->render(array("var" => "test"));
+		$this->assertEquals("[test] (test)", $output);
 	}
 }


### PR DESCRIPTION
This allows the use of unquoted template names like for Jekyll for example (https://jekyllrb.com/docs/includes/)