### PR TITLE
Additional tests for Include and Extends

### DIFF
--- a/tests/Liquid/Tag/TagExtendsTest.php
+++ b/tests/Liquid/Tag/TagExtendsTest.php
@@ -105,7 +105,8 @@ class TagExtendsTest extends TestCase
 		$template = new Template();
 		$template->setFileSystem(TestFileSystem::fromArray(array(
 			'outer' => "{% block content %}Outer{{ a }}{% endblock %}Spacer{{ a }}{% block footer %}Footer{{ a }}{% endblock %}",
-			'middle' => "{% extends 'outer' %}{% block content %}Inner{{ a }}{% endblock %}",
+			'middle' => "{% extends 'outer' %}{% block content %}Middle{{ a }}{% endblock %}",
+			'inner' => "{% extends 'middle' %}{% block content %}Inner{{ a }}{% endblock %}",
 		)));
 
 		$template->setCache(new Local());
@@ -113,7 +114,8 @@ class TagExtendsTest extends TestCase
 		$template->parseFile('outer')->render(['a' => '0']);
 		$template->parseFile('middle')->render(['a' => '1']);
 		$template->parseFile('middle')->render(['a' => '2']);
-		$this->assertEquals('Inner3Spacer3Footer3', $template->parseFile('middle')->render(['a' => '3']));
+		$this->assertEquals('Middle3Spacer3Footer3', $template->parseFile('middle')->render(['a' => '3']));
+		$this->assertEquals('Inner4Spacer4Footer4', $template->parseFile('inner')->render(['a' => '4']));
 	}
 
 	public function testCacheDiscardedIfFileChanges()

--- a/tests/Liquid/Tag/TagIncludeTest.php
+++ b/tests/Liquid/Tag/TagIncludeTest.php
@@ -223,4 +223,24 @@ class TagIncludeTest extends TestCase
 
 		$template->setCache(null);
 	}
+
+	public function testCacheDiscardedIfFileChanges()
+	{
+		$template = new Template();
+		$template->setCache(new Local());
+
+		$content = "[{{ name }}]";
+		$template->setFileSystem(TestFileSystem::fromArray(array(
+			'example' => &$content,
+		)));
+
+		$template->parse("{% include 'example' %}");
+		$output = $template->render(array("name" => "Example"));
+		$this->assertEquals("[Example]", $output);
+
+		$content = "<{{ name }}>";
+		$template->parse("{% include 'example' %}");
+		$output = $template->render(array("name" => "Example"));
+		$this->assertEquals("<Example>", $output);
+	}
 }

--- a/tests/Liquid/Tag/TagRawTest.php
+++ b/tests/Liquid/Tag/TagRawTest.php
@@ -18,8 +18,8 @@ class TagRawTest extends TestCase
 	public function testRaw()
 	{
 		$this->assertTemplateResult(
-			'{{ y | plus: x }}{{{hello}}} is equal to 11.',
-			'{% raw %}{{ y | plus: x }}{{{hello}}}{% endraw %} is equal to 11.',
+			'{{ y | plus: x }}{% if %} is equal to 11.',
+			'{% raw %}{{ y | plus: x }}{% if %}{% endraw %} is equal to 11.',
 			array('x' => 5, 'y' => 6)
 		);
 


### PR DESCRIPTION
We try to keep the base templates in cache (that not extend anything).

At the same time if we re-render all other blocks we see, we avoid most if not all related caching quirks. This may be suboptimal, but that's what we have for now.
