### PR TITLE
Allow using `FILTER_SEPARATOR` as a split filter parameter in filters for variable assignment

### DIFF
--- a/src/Liquid/Liquid.php
+++ b/src/Liquid/Liquid.php
@@ -94,8 +94,6 @@ class Liquid
 		switch ($key) {
 				case 'QUOTED_FRAGMENT':
 					return self::$config['QUOTED_STRING'] . '|(?:[^\s,\|\'"]|' . self::$config['QUOTED_STRING'] . ')+';
-				case 'QUOTED_FRAGMENT_FILTER_ARGUMENT':
-					return self::$config['QUOTED_STRING_FILTER_ARGUMENT'] . '|(?:[^\s:,\|\'"]|' . self::$config['QUOTED_STRING_FILTER_ARGUMENT'] . ')+';
 				case 'TAG_ATTRIBUTES':
 					return '/(\w+)\s*\:\s*(' . self::get('QUOTED_FRAGMENT') . ')/';
 				case 'TOKENIZATION_REGEXP':

--- a/src/Liquid/Tag/TagAssign.php
+++ b/src/Liquid/Tag/TagAssign.php
@@ -17,6 +17,7 @@ use Liquid\LiquidException;
 use Liquid\FileSystem;
 use Liquid\Regexp;
 use Liquid\Context;
+use Liquid\Variable;
 
 /**
  * Performs an assignment of one variable to another
@@ -49,32 +50,11 @@ class TagAssign extends AbstractTag
 	 */
 	public function __construct($markup, array &$tokens, FileSystem $fileSystem = null)
 	{
-		$syntaxRegexp = new Regexp('/(\w+)\s*=\s*(' . Liquid::get('QUOTED_FRAGMENT') . '+)/');
-
-		$filterSeperatorRegexp = new Regexp('/' . Liquid::get('FILTER_SEPARATOR') . '\s*(.*)/');
-		$filterSplitRegexp = new Regexp('/' . Liquid::get('FILTER_SEPARATOR') . '/');
-		$filterNameRegexp = new Regexp('/\s*(\w+)/');
-		$filterArgumentRegexp = new Regexp('/(?:' . Liquid::get('FILTER_ARGUMENT_SEPARATOR') . '|' . Liquid::get('ARGUMENT_SEPARATOR') . ')\s*(' . Liquid::get('QUOTED_FRAGMENT') . ')/');
-
-		$this->filters = array();
-
-		if ($filterSeperatorRegexp->match($markup)) {
-			$filters = $filterSplitRegexp->split($filterSeperatorRegexp->matches[1]);
-
-			foreach ($filters as $filter) {
-				$filterNameRegexp->match($filter);
-				$filtername = $filterNameRegexp->matches[1];
-
-				$filterArgumentRegexp->matchAll($filter);
-				$matches = Liquid::arrayFlatten($filterArgumentRegexp->matches[1]);
-
-				array_push($this->filters, array($filtername, $matches));
-			}
-		}
+		$syntaxRegexp = new Regexp('/(\w+)\s*=\s*(.*)\s*/');
 
 		if ($syntaxRegexp->match($markup)) {
 			$this->to = $syntaxRegexp->matches[1];
-			$this->from = $syntaxRegexp->matches[2];
+			$this->from = new Variable($syntaxRegexp->matches[2]);
 		} else {
 			throw new LiquidException("Syntax Error in 'assign' - Valid syntax: assign [var] = [source]");
 		}
@@ -89,19 +69,7 @@ class TagAssign extends AbstractTag
 	 */
 	public function render(Context $context)
 	{
-		$output = $context->get($this->from);
-
-		foreach ($this->filters as $filter) {
-			list($filtername, $filterArgKeys) = $filter;
-
-			$filterArgValues = array();
-
-			foreach ($filterArgKeys as $arg_key) {
-				$filterArgValues[] = $context->get($arg_key);
-			}
-
-			$output = $context->invoke($filtername, $output, $filterArgValues);
-		}
+		$output = $this->from->render($context);
 
 		$context->set($this->to, $output, true);
 	}

--- a/src/Liquid/Variable.php
+++ b/src/Liquid/Variable.php
@@ -40,30 +40,30 @@ class Variable
 	{
 		$this->markup = $markup;
 
-		$quotedFragmentRegexp = new Regexp('/\s*(' . Liquid::get('QUOTED_FRAGMENT') . ')/');
-		$filterSeperatorRegexp = new Regexp('/' . Liquid::get('FILTER_SEPARATOR') . '\s*(.*)/');
-		$filterSplitRegexp = new Regexp('/' . Liquid::get('FILTER_SEPARATOR') . '/');
-		$filterNameRegexp = new Regexp('/\s*(\w+)/');
-		$filterArgumentRegexp = new Regexp('/(?:' . Liquid::get('FILTER_ARGUMENT_SEPARATOR') . '|' . Liquid::get('ARGUMENT_SEPARATOR') . ')\s*(' . Liquid::get('QUOTED_FRAGMENT_FILTER_ARGUMENT') . ')/');
+		$filterSep = new Regexp('/' . Liquid::get('FILTER_SEPARATOR') . '\s*(.*)/m');
+		$syntaxParser = new Regexp('/(' . Liquid::get('QUOTED_FRAGMENT') . ')(.*)/m');
+		$filterParser = new Regexp('/(?:\s+|' . Liquid::get('QUOTED_FRAGMENT') . '|' . Liquid::get('ARGUMENT_SEPARATOR') . ')+/');
+		$filterArgsRegex = new Regexp('/(?:' . Liquid::get('FILTER_ARGUMENT_SEPARATOR') . '|' . Liquid::get('ARGUMENT_SEPARATOR') . ')\s*((?:\w+\s*\:\s*)?' . Liquid::get('QUOTED_FRAGMENT') . ')/');
 
-		$quotedFragmentRegexp->match($markup);
+		$this->filters = [];
+		if ($syntaxParser->match($markup)) {
+			$nameMarkup = $syntaxParser->matches[1];
+			$this->name = $nameMarkup;
+			$filterMarkup = $syntaxParser->matches[2];
 
-		$this->name = (isset($quotedFragmentRegexp->matches[1])) ? $quotedFragmentRegexp->matches[1] : null;
+			if ($filterSep->match($filterMarkup)) {
+				$filterParser->matchAll($filterSep->matches[1]);
 
-		if ($filterSeperatorRegexp->match($markup)) {
-			$filters = $filterSplitRegexp->split($filterSeperatorRegexp->matches[1]);
-
-			foreach ($filters as $filter) {
-				$filterNameRegexp->match($filter);
-				$filtername = $filterNameRegexp->matches[1];
-
-				$filterArgumentRegexp->matchAll($filter);
-				$matches = Liquid::arrayFlatten($filterArgumentRegexp->matches[1]);
-
-				$this->filters[] = array($filtername, $matches);
+				foreach ($filterParser->matches[0] as $filter) {
+					$filter = trim($filter);
+					if (preg_match('/\w+/', $filter, $matches)) {
+						$filterName = $matches[0];
+						$filterArgsRegex->matchAll($filter);
+						$matches = Liquid::arrayFlatten($filterArgsRegex->matches[1]);
+						$this->filters[] = array($filterName, $matches);
+					}
+				}
 			}
-		} else {
-			$this->filters = array();
 		}
 
 		if (Liquid::get('ESCAPE_BY_DEFAULT')) {
@@ -90,6 +90,7 @@ class Variable
 			}
 		}
 	}
+
 
 	/**
 	 * Gets the variable name
@@ -121,7 +122,6 @@ class Variable
 	public function render(Context $context)
 	{
 		$output = $context->get($this->name);
-
 		foreach ($this->filters as $filter) {
 			list($filtername, $filterArgKeys) = $filter;
 
@@ -133,7 +133,6 @@ class Variable
 
 			$output = $context->invoke($filtername, $output, $filterArgValues);
 		}
-
 		return $output;
 	}
 }

--- a/tests/Liquid/AbstractBlockTest.php
+++ b/tests/Liquid/AbstractBlockTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Liquid package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package Liquid
+ */
+
+namespace Liquid\Tag;
+
+use Liquid\TestCase;
+
+class AbstractBlockTest extends TestCase
+{
+	/**
+	 * @expectedException \Liquid\LiquidException
+	 */
+	public function testUnterminatedBlockError()
+	{
+		$this->assertTemplateResult('', '{% block }');
+	}
+}

--- a/tests/Liquid/Tag/TagAssignTest.php
+++ b/tests/Liquid/Tag/TagAssignTest.php
@@ -70,6 +70,20 @@ class TagAssignTest extends TestCase
 	}
 
 	/**
+	 * Tests filtered value assignment with separators
+	 */
+	public function testTagAssignWithSplit()
+	{
+		$template = new Template();
+
+		$template->parse('{% assign rows = "one|two|three,one|two|three" | upcase | split: "," %}{% for row in rows %}{% assign cols = row | split: "|" %}{% for col in cols %} {{col}}{%endfor%}{% endfor %}');
+		$this->assertEquals($template->render(), ' ONE TWO THREE ONE TWO THREE');
+
+		$template->parse('{% assign issue_numbers = "1339|1338|1321" | split: "|" %}{% for issue in issue_numbers %} {{ issue }}{% endfor %}');
+		$this->assertEquals($template->render(), ' 1339 1338 1321');
+	}
+
+	/**
 	 * Tests a simple assignment with numbers
 	 */
 	public function testNumbersAssign()

--- a/tests/Liquid/TestCase.php
+++ b/tests/Liquid/TestCase.php
@@ -39,7 +39,6 @@ class TestCase extends \PHPUnit_Framework_TestCase
 			'VARIABLE_START' => '{{',
 			'VARIABLE_END' => '}}',
 			'VARIABLE_NAME' => '[a-zA-Z_][a-zA-Z0-9_.-]*',
-			'QUOTED_STRING' => '"[^":]*"|\'[^\':]*\'',
 		);
 
 		foreach ($defaultConfig as $configKey => $configValue) {


### PR DESCRIPTION
Refactor TagAssign to use a `Variable` instance in the value assignment instead of a string. Remove `QUOTED_STRING` config from the TestCase as it was different from the default config for no reason that I could see.