### PR TITLE
More on building and testing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+- [ ] I've run the tests with `vendor/bin/phpunit`
+- [ ] None of the tests were found failing
+- [ ] I've seen the coverage report at `build/coverage/index.html`
+- [ ] Not a single line left uncovered by tests
+- [ ] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`
+- [ ] Hotfix-type commits were squashed with `git rebase -i` or `git commit --amend`
+- [ ] All my work wasn't smushed into one large commit without necessity

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,14 @@ php:
 cache:
   directories:
     - $HOME/.composer/cache
+    - build/cache
 
 install:
   - composer install --prefer-dist
 
 script:
   - vendor/bin/phpunit --verbose || travis_terminate 1
-  - vendor/bin/php-cs-fixer --diff --dry-run --stop-on-violation --verbose fix
+  - mkdir -p build/cache && vendor/bin/php-cs-fixer --cache-file=build/cache/.php_cs.cache --diff --dry-run --stop-on-violation --verbose fix
 
 after_success:
   - travis_retry php vendor/bin/coveralls

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,5 +15,6 @@
 	<logging>
 		<log type="coverage-clover" target="build/logs/clover.xml"/>
 		<log type="coverage-text" target="php://stdout"/>
+		<log type="coverage-html" target="build/coverage/" lowUpperBound="35" highLowerBound="70"/>
 	</logging>
 </phpunit>


### PR DESCRIPTION
* [x] Always create HTML coverage logs
* [x] Keep PHP CS Fixer cache between builds (about 20 seconds speed-up)
* [ ] Add a note about contributing