### PR TITLE
Throw different types of exception depending on the case instead of always throwing a LiquidException

### DIFF
--- a/src/Liquid/AbstractBlock.php
+++ b/src/Liquid/AbstractBlock.php
@@ -11,6 +11,9 @@
 
 namespace Liquid;
 
+use Liquid\Exception\ParseException;
+use Liquid\Exception\RenderException;
+
 /**
  * Base class for blocks.
  */
@@ -75,7 +78,7 @@ class AbstractBlock extends AbstractTag
 						$this->unknownTag($tagRegexp->matches[1], $tagRegexp->matches[2], $tokens);
 					}
 				} else {
-					throw new LiquidException("Tag $token was not properly terminated"); // harry
+					throw new ParseException("Tag $token was not properly terminated"); // harry
 				}
 			} elseif ($variableStartRegexp->match($token)) {
 				$this->nodelist[] = $this->createVariable($token);
@@ -119,7 +122,7 @@ class AbstractBlock extends AbstractTag
 			}
 
 			if (is_array($value)) {
-				throw new LiquidException("Implicit rendering of arrays not supported. Use index operator.");
+				throw new RenderException("Implicit rendering of arrays not supported. Use index operator.");
 			}
 
 			$result .= $value;
@@ -150,30 +153,30 @@ class AbstractBlock extends AbstractTag
 	 * @param string $params
 	 * @param array $tokens
 	 *
-	 * @throws \Liquid\LiquidException
+	 * @throws \Liquid\Exception\ParseException
 	 */
 	protected function unknownTag($tag, $params, array $tokens)
 	{
 		switch ($tag) {
 			case 'else':
-				throw new LiquidException($this->blockName() . " does not expect else tag");
+				throw new ParseException($this->blockName() . " does not expect else tag");
 			case 'end':
-				throw new LiquidException("'end' is not a valid delimiter for " . $this->blockName() . " tags. Use " . $this->blockDelimiter());
+				throw new ParseException("'end' is not a valid delimiter for " . $this->blockName() . " tags. Use " . $this->blockDelimiter());
 			default:
-				throw new LiquidException("Unknown tag $tag");
+				throw new ParseException("Unknown tag $tag");
 		}
 	}
 
 	/**
-	 * This method is called at the end of parsing, and will through an error unless
+	 * This method is called at the end of parsing, and will throw an error unless
 	 * this method is subclassed, like it is for Document
 	 *
-	 * @throws \Liquid\LiquidException
+	 * @throws \Liquid\Exception\ParseException
 	 * @return bool
 	 */
 	protected function assertMissingDelimitation()
 	{
-		throw new LiquidException($this->blockName() . " tag was never closed");
+		throw new ParseException($this->blockName() . " tag was never closed");
 	}
 
 	/**
@@ -202,7 +205,7 @@ class AbstractBlock extends AbstractTag
 	 *
 	 * @param string $token
 	 *
-	 * @throws \Liquid\LiquidException
+	 * @throws \Liquid\Exception\ParseException
 	 * @return Variable
 	 */
 	private function createVariable($token)
@@ -212,6 +215,6 @@ class AbstractBlock extends AbstractTag
 			return new Variable($variableRegexp->matches[1]);
 		}
 
-		throw new LiquidException("Variable $token was not properly terminated");
+		throw new ParseException("Variable $token was not properly terminated");
 	}
 }

--- a/src/Liquid/Cache/File.php
+++ b/src/Liquid/Cache/File.php
@@ -12,7 +12,7 @@
 namespace Liquid\Cache;
 
 use Liquid\Cache;
-use Liquid\LiquidException;
+use Liquid\Exception\NotFoundException;
 
 /**
  * Implements cache stored in files.
@@ -26,7 +26,7 @@ class File extends Cache
 	 *
 	 * @param array $options
 	 *
-	 * @throws LiquidException if Cachedir not exists.
+	 * @throws NotFoundException if Cachedir not exists.
 	 */
 	public function __construct(array $options = array())
 	{
@@ -35,7 +35,7 @@ class File extends Cache
 		if (isset($options['cache_dir']) && is_writable($options['cache_dir'])) {
 			$this->path = realpath($options['cache_dir']) . DIRECTORY_SEPARATOR;
 		} else {
-			throw new LiquidException('Cachedir not exists or not writable');
+			throw new NotFoundException('Cachedir not exists or not writable');
 		}
 	}
 

--- a/src/Liquid/Decision.php
+++ b/src/Liquid/Decision.php
@@ -11,6 +11,8 @@
 
 namespace Liquid;
 
+use Liquid\Exception\RenderException;
+
 /**
  * Base class for blocks that make logical decisions.
  */
@@ -35,7 +37,7 @@ class Decision extends AbstractBlock
 	 *
 	 * @param mixed $value
 	 *
-	 * @throws \Liquid\LiquidException
+	 * @throws \Liquid\Exception\RenderException
 	 * @return string
 	 */
 	private function stringValue($value)
@@ -47,7 +49,7 @@ class Decision extends AbstractBlock
 			} else {
 				// toLiquid is handled in Context::variable
 				$class = get_class($value);
-				throw new LiquidException("Value of type $class has no `toLiquid` nor `__toString` methods");
+				throw new RenderException("Value of type $class has no `toLiquid` nor `__toString` methods");
 			}
 		}
 
@@ -84,7 +86,7 @@ class Decision extends AbstractBlock
 	 * @param string $op
 	 * @param Context $context
 	 *
-	 * @throws \Liquid\LiquidException
+	 * @throws \Liquid\Exception\RenderException
 	 * @return bool
 	 */
 	protected function interpretCondition($left, $right, $op, Context $context)
@@ -149,7 +151,7 @@ class Decision extends AbstractBlock
 				return is_array($left) ? in_array($right, $left) : (strpos($left, $right) !== false);
 
 			default:
-				throw new LiquidException("Error in tag '" . $this->name() . "' - Unknown operator $op");
+				throw new RenderException("Error in tag '" . $this->name() . "' - Unknown operator $op");
 		}
 	}
 }

--- a/src/Liquid/Exception/CacheException.php
+++ b/src/Liquid/Exception/CacheException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Liquid package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package Liquid
+ */
+
+namespace Liquid\Exception;
+
+use Liquid\LiquidException;
+
+/**
+ * CacheException class.
+ */
+class CacheException extends LiquidException
+{
+}

--- a/src/Liquid/Exception/FilesystemException.php
+++ b/src/Liquid/Exception/FilesystemException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Liquid package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package Liquid
+ */
+
+namespace Liquid\Exception;
+
+use Liquid\LiquidException;
+
+/**
+ * FilesystemException class.
+ */
+class FilesystemException extends LiquidException
+{
+}

--- a/src/Liquid/Exception/MissingFilesystemException.php
+++ b/src/Liquid/Exception/MissingFilesystemException.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Liquid package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package Liquid
+ */
+
+namespace Liquid\Exception;
+
+use Liquid\Exception\ParseException;
+
+/**
+ * Class MissingFilesystemException
+ * @package Liquid\Exception
+ */
+class MissingFilesystemException extends ParseException
+{
+}

--- a/src/Liquid/Exception/NotFoundException.php
+++ b/src/Liquid/Exception/NotFoundException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Liquid package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package Liquid
+ */
+
+namespace Liquid\Exception;
+
+use Liquid\Exception\FilesystemException;
+
+/**
+ * NotFoundException class.
+ */
+class NotFoundException extends FilesystemException
+{
+}

--- a/src/Liquid/Exception/ParseException.php
+++ b/src/Liquid/Exception/ParseException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Liquid package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package Liquid
+ */
+
+namespace Liquid\Exception;
+
+use Liquid\LiquidException;
+
+/**
+ * ParseException class.
+ */
+class ParseException extends LiquidException
+{
+}

--- a/src/Liquid/Exception/RenderException.php
+++ b/src/Liquid/Exception/RenderException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Liquid package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package Liquid
+ */
+
+namespace Liquid\Exception;
+
+use Liquid\LiquidException;
+
+/**
+ * RenderException class.
+ */
+class RenderException extends LiquidException
+{
+}

--- a/src/Liquid/Exception/WrongArgumentException.php
+++ b/src/Liquid/Exception/WrongArgumentException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Liquid package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package Liquid
+ */
+
+namespace Liquid\Exception;
+
+use Liquid\LiquidException;
+
+/**
+ * WrongArgumentException class.
+ */
+class WrongArgumentException extends LiquidException
+{
+}

--- a/src/Liquid/FileSystem/Local.php
+++ b/src/Liquid/FileSystem/Local.php
@@ -11,8 +11,9 @@
 
 namespace Liquid\FileSystem;
 
+use Liquid\Exception\NotFoundException;
+use Liquid\Exception\ParseException;
 use Liquid\FileSystem;
-use Liquid\LiquidException;
 use Liquid\Regexp;
 use Liquid\Liquid;
 
@@ -35,6 +36,7 @@ class Local implements FileSystem
 	 * Constructor
 	 *
 	 * @param string $root The root path for templates
+	 * @throws \Liquid\Exception\NotFoundException
 	 */
 	public function __construct($root)
 	{
@@ -42,7 +44,7 @@ class Local implements FileSystem
 		if (!empty($root)) {
 			$realRoot = realpath($root);
 			if ($realRoot === false) {
-				throw new LiquidException("Root path could not be found: '$root'");
+				throw new NotFoundException("Root path could not be found: '$root'");
 			}
 			$root = $realRoot;
 		}
@@ -67,13 +69,14 @@ class Local implements FileSystem
 	 *
 	 * @param string $templatePath
 	 *
-	 * @throws LiquidException
+	 * @throws \Liquid\Exception\ParseException
+	 * @throws \Liquid\Exception\NotFoundException
 	 * @return string
 	 */
 	public function fullPath($templatePath)
 	{
 		if (empty($templatePath)) {
-			throw new LiquidException("Empty template name");
+			throw new ParseException("Empty template name");
 		}
 
 		$nameRegex = Liquid::get('INCLUDE_ALLOW_EXT')
@@ -81,7 +84,7 @@ class Local implements FileSystem
 		: new Regexp('/^[^.\/][a-zA-Z0-9_\/]+$/');
 
 		if (!$nameRegex->match($templatePath)) {
-			throw new LiquidException("Illegal template name '$templatePath'");
+			throw new ParseException("Illegal template name '$templatePath'");
 		}
 
 		$templateDir = dirname($templatePath);
@@ -95,11 +98,11 @@ class Local implements FileSystem
 
 		$realFullPath = realpath($fullPath);
 		if ($realFullPath === false) {
-			throw new LiquidException("File not found: $fullPath");
+			throw new NotFoundException("File not found: $fullPath");
 		}
 
 		if (strpos($realFullPath, $this->root) !== 0) {
-			throw new LiquidException("Illegal template full path: {$realFullPath} not under {$this->root}");
+			throw new NotFoundException("Illegal template full path: {$realFullPath} not under {$this->root}");
 		}
 
 		return $realFullPath;

--- a/src/Liquid/FileSystem/Virtual.php
+++ b/src/Liquid/FileSystem/Virtual.php
@@ -11,8 +11,8 @@
 
 namespace Liquid\FileSystem;
 
+use Liquid\Exception\FilesystemException;
 use Liquid\FileSystem;
-use Liquid\LiquidException;
 
 /**
  * This implements a virtual file system with actual code used to find files injected from outside thus achieving inversion of control.
@@ -28,13 +28,13 @@ class Virtual implements FileSystem
 	 * Constructor
 	 *
 	 * @param callable $callback Callback is responsible for providing content of requested templates. Should return template's text.
-	 * @throws LiquidException
+	 * @throws \Liquid\Exception\FilesystemException
 	 */
 	public function __construct($callback)
 	{
 		// Since a callback can only be set from the constructor, we check it once right here.
 		if (!is_callable($callback)) {
-			throw new LiquidException("Not a callback provided");
+			throw new FilesystemException("Not a callback provided");
 		}
 
 		$this->callback = $callback;
@@ -56,7 +56,7 @@ class Virtual implements FileSystem
 	{
 		// we cannot serialize a closure
 		if ($this->callback instanceof \Closure) {
-			throw new LiquidException("Virtual file system with a Closure as a callback cannot be used with a serializing cache");
+			throw new FilesystemException("Virtual file system with a Closure as a callback cannot be used with a serializing cache");
 		}
 
 		return array_keys(get_object_vars($this));

--- a/src/Liquid/Filterbank.php
+++ b/src/Liquid/Filterbank.php
@@ -11,6 +11,8 @@
 
 namespace Liquid;
 
+use Liquid\Exception\WrongArgumentException;
+
 /**
  * The filter bank is where all registered filters are stored, and where filter invocation is handled
  * it supports a variety of different filter types; objects, class, and simple methods.
@@ -57,7 +59,7 @@ class Filterbank
 	 * @param mixed $filter Can either be an object, the name of a class (in which case the
 	 *						filters will be called statically) or the name of a function.
 	 *
-	 * @throws LiquidException
+	 * @throws \Liquid\Exception\WrongArgumentException
 	 * @return bool
 	 */
 	public function addFilter($filter)
@@ -72,7 +74,7 @@ class Filterbank
 
 		// If it wasn't an object an isn't a string either, it's a bad parameter
 		if (!is_string($filter)) {
-			throw new LiquidException("Parameter passed to addFilter must be an object or a string");
+			throw new WrongArgumentException("Parameter passed to addFilter must be an object or a string");
 		}
 
 		// If the filter is a class, register all its methods
@@ -91,7 +93,7 @@ class Filterbank
 			return true;
 		}
 
-		throw new LiquidException("Parameter passed to addFilter must a class or a function");
+		throw new WrongArgumentException("Parameter passed to addFilter must a class or a function");
 	}
 
 	/**

--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -11,6 +11,8 @@
 
 namespace Liquid;
 
+use Liquid\Exception\RenderException;
+
 /**
  * A selection of standard filters.
  */
@@ -450,7 +452,7 @@ class StandardFilters
 	 * Return the size of an array or of an string
 	 *
 	 * @param mixed $input
-	 *
+	 * @throws RenderException
 	 * @return int
 	 */
 	public static function size($input)
@@ -470,7 +472,7 @@ class StandardFilters
 
 			if (!method_exists($input, '__toString')) {
 				$class = get_class($input);
-				throw new LiquidException("Size of $class cannot be estimated: it has no method 'size' nor can be converted to a string");
+				throw new RenderException("Size of $class cannot be estimated: it has no method 'size' nor can be converted to a string");
 			}
 		}
 

--- a/src/Liquid/Tag/TagAssign.php
+++ b/src/Liquid/Tag/TagAssign.php
@@ -12,8 +12,8 @@
 namespace Liquid\Tag;
 
 use Liquid\AbstractTag;
+use Liquid\Exception\ParseException;
 use Liquid\Liquid;
-use Liquid\LiquidException;
 use Liquid\FileSystem;
 use Liquid\Regexp;
 use Liquid\Context;
@@ -46,7 +46,7 @@ class TagAssign extends AbstractTag
 	 * @param array $tokens
 	 * @param FileSystem $fileSystem
 	 *
-	 * @throws \Liquid\LiquidException
+	 * @throws \Liquid\Exception\ParseException
 	 */
 	public function __construct($markup, array &$tokens, FileSystem $fileSystem = null)
 	{
@@ -56,7 +56,7 @@ class TagAssign extends AbstractTag
 			$this->to = $syntaxRegexp->matches[1];
 			$this->from = new Variable($syntaxRegexp->matches[2]);
 		} else {
-			throw new LiquidException("Syntax Error in 'assign' - Valid syntax: assign [var] = [source]");
+			throw new ParseException("Syntax Error in 'assign' - Valid syntax: assign [var] = [source]");
 		}
 	}
 

--- a/src/Liquid/Tag/TagBlock.php
+++ b/src/Liquid/Tag/TagBlock.php
@@ -12,7 +12,7 @@
 namespace Liquid\Tag;
 
 use Liquid\AbstractBlock;
-use Liquid\LiquidException;
+use Liquid\Exception\ParseException;
 use Liquid\FileSystem;
 use Liquid\Regexp;
 
@@ -39,7 +39,7 @@ class TagBlock extends AbstractBlock
 	 * @param array $tokens
 	 * @param FileSystem $fileSystem
 	 *
-	 * @throws \Liquid\LiquidException
+	 * @throws \Liquid\Exception\ParseException
 	 * @return \Liquid\Tag\TagBlock
 	 */
 	public function __construct($markup, array &$tokens, FileSystem $fileSystem = null)
@@ -50,7 +50,7 @@ class TagBlock extends AbstractBlock
 			$this->block = $syntaxRegexp->matches[1];
 			parent::__construct($markup, $tokens, $fileSystem);
 		} else {
-			throw new LiquidException("Syntax Error in 'block' - Valid syntax: block [name]");
+			throw new ParseException("Syntax Error in 'block' - Valid syntax: block [name]");
 		}
 	}
 }

--- a/src/Liquid/Tag/TagCapture.php
+++ b/src/Liquid/Tag/TagCapture.php
@@ -13,7 +13,7 @@ namespace Liquid\Tag;
 
 use Liquid\AbstractBlock;
 use Liquid\Context;
-use Liquid\LiquidException;
+use Liquid\Exception\ParseException;
 use Liquid\FileSystem;
 use Liquid\Regexp;
 
@@ -40,7 +40,7 @@ class TagCapture extends AbstractBlock
 	 * @param array $tokens
 	 * @param FileSystem $fileSystem
 	 *
-	 * @throws \Liquid\LiquidException
+	 * @throws \Liquid\Exception\ParseException
 	 */
 	public function __construct($markup, array &$tokens, FileSystem $fileSystem = null)
 	{
@@ -50,7 +50,7 @@ class TagCapture extends AbstractBlock
 			$this->to = $syntaxRegexp->matches[1];
 			parent::__construct($markup, $tokens, $fileSystem);
 		} else {
-			throw new LiquidException("Syntax Error in 'capture' - Valid syntax: capture [var] [value]");
+			throw new ParseException("Syntax Error in 'capture' - Valid syntax: capture [var] [value]");
 		}
 	}
 

--- a/src/Liquid/Tag/TagCase.php
+++ b/src/Liquid/Tag/TagCase.php
@@ -13,8 +13,8 @@ namespace Liquid\Tag;
 
 use Liquid\Decision;
 use Liquid\Context;
+use Liquid\Exception\ParseException;
 use Liquid\Liquid;
-use Liquid\LiquidException;
 use Liquid\FileSystem;
 use Liquid\Regexp;
 
@@ -62,7 +62,7 @@ class TagCase extends Decision
 	 * @param array $tokens
 	 * @param FileSystem $fileSystem
 	 *
-	 * @throws \Liquid\LiquidException
+	 * @throws \Liquid\Exception\ParseException
 	 */
 	public function __construct($markup, array &$tokens, FileSystem $fileSystem = null)
 	{
@@ -76,7 +76,7 @@ class TagCase extends Decision
 		if ($syntaxRegexp->match($markup)) {
 			$this->left = $syntaxRegexp->matches[0];
 		} else {
-			throw new LiquidException("Syntax Error in tag 'case' - Valid syntax: case [condition]"); // harry
+			throw new ParseException("Syntax Error in tag 'case' - Valid syntax: case [condition]"); // harry
 		}
 	}
 
@@ -95,7 +95,7 @@ class TagCase extends Decision
 	 * @param string $params
 	 * @param array $tokens
 	 *
-	 * @throws \Liquid\LiquidException
+	 * @throws \Liquid\Exception\ParseException
 	 */
 	public function unknownTag($tag, $params, array $tokens)
 	{
@@ -109,7 +109,7 @@ class TagCase extends Decision
 					$this->right = $whenSyntaxRegexp->matches[0];
 					$this->nodelist = array();
 				} else {
-					throw new LiquidException("Syntax Error in tag 'case' - Valid when condition: when [condition]"); // harry
+					throw new ParseException("Syntax Error in tag 'case' - Valid when condition: when [condition]"); // harry
 				}
 				break;
 

--- a/src/Liquid/Tag/TagCycle.php
+++ b/src/Liquid/Tag/TagCycle.php
@@ -12,9 +12,9 @@
 namespace Liquid\Tag;
 
 use Liquid\AbstractTag;
+use Liquid\Exception\ParseException;
 use Liquid\Liquid;
 use Liquid\Context;
-use Liquid\LiquidException;
 use Liquid\Regexp;
 use Liquid\Variable;
 use Liquid\FileSystem;
@@ -53,7 +53,7 @@ class TagCycle extends AbstractTag
 	 * @param array $tokens
 	 * @param FileSystem $fileSystem
 	 *
-	 * @throws LiquidException
+	 * @throws \Liquid\Exception\ParseException
 	 */
 	public function __construct($markup, array &$tokens, FileSystem $fileSystem = null)
 	{
@@ -67,7 +67,7 @@ class TagCycle extends AbstractTag
 			$this->variables = $this->variablesFromString($markup);
 			$this->name = "'" . implode($this->variables) . "'";
 		} else {
-			throw new LiquidException("Syntax Error in 'cycle' - Valid syntax: cycle [name :] var [, var2, var3 ...]");
+			throw new ParseException("Syntax Error in 'cycle' - Valid syntax: cycle [name :] var [, var2, var3 ...]");
 		}
 	}
 

--- a/src/Liquid/Tag/TagDecrement.php
+++ b/src/Liquid/Tag/TagDecrement.php
@@ -12,9 +12,9 @@
 namespace Liquid\Tag;
 
 use Liquid\AbstractTag;
+use Liquid\Exception\ParseException;
 use Liquid\Liquid;
 use Liquid\Context;
-use Liquid\LiquidException;
 use Liquid\FileSystem;
 use Liquid\Regexp;
 
@@ -43,7 +43,7 @@ class TagDecrement extends AbstractTag
 	 * @param array $tokens
 	 * @param FileSystem $fileSystem
 	 *
-	 * @throws \Liquid\LiquidException
+	 * @throws \Liquid\Exception\ParseException
 	 */
 	public function __construct($markup, array &$tokens, FileSystem $fileSystem = null)
 	{
@@ -52,7 +52,7 @@ class TagDecrement extends AbstractTag
 		if ($syntax->match($markup)) {
 			$this->toDecrement = $syntax->matches[0];
 		} else {
-			throw new LiquidException("Syntax Error in 'decrement' - Valid syntax: decrement [var]");
+			throw new ParseException("Syntax Error in 'decrement' - Valid syntax: decrement [var]");
 		}
 	}
 

--- a/src/Liquid/Tag/TagExtends.php
+++ b/src/Liquid/Tag/TagExtends.php
@@ -13,9 +13,10 @@ namespace Liquid\Tag;
 
 use Liquid\AbstractTag;
 use Liquid\Document;
+use Liquid\Exception\FilesystemException;
+use Liquid\Exception\ParseException;
 use Liquid\Liquid;
 use Liquid\Context;
-use Liquid\LiquidException;
 use Liquid\FileSystem;
 use Liquid\Regexp;
 use Liquid\Template;
@@ -51,7 +52,7 @@ class TagExtends extends AbstractTag
 	 * @param array $tokens
 	 * @param FileSystem $fileSystem
 	 *
-	 * @throws \Liquid\LiquidException
+	 * @throws \Liquid\Exception\ParseException
 	 */
 	public function __construct($markup, array &$tokens, FileSystem $fileSystem = null)
 	{
@@ -60,7 +61,7 @@ class TagExtends extends AbstractTag
 		if ($regex->match($markup) && isset($regex->matches[1])) {
 			$this->templateName = substr($regex->matches[1], 1, strlen($regex->matches[1]) - 2);
 		} else {
-			throw new LiquidException("Error in tag 'extends' - Valid syntax: extends '[template name]'");
+			throw new ParseException("Error in tag 'extends' - Valid syntax: extends '[template name]'");
 		}
 
 		parent::__construct($markup, $tokens, $fileSystem);
@@ -100,12 +101,12 @@ class TagExtends extends AbstractTag
 	 *
 	 * @param array $tokens
 	 *
-	 * @throws \Liquid\LiquidException
+	 * @throws \Liquid\Exception\FilesystemException
 	 */
 	public function parse(array &$tokens)
 	{
 		if ($this->fileSystem === null) {
-			throw new LiquidException("No file system");
+			throw new FilesystemException("No file system");
 		}
 
 		// read the source of the template and create a new sub document

--- a/src/Liquid/Tag/TagExtends.php
+++ b/src/Liquid/Tag/TagExtends.php
@@ -13,7 +13,7 @@ namespace Liquid\Tag;
 
 use Liquid\AbstractTag;
 use Liquid\Document;
-use Liquid\Exception\FilesystemException;
+use Liquid\Exception\MissingFilesystemException;
 use Liquid\Exception\ParseException;
 use Liquid\Liquid;
 use Liquid\Context;
@@ -101,12 +101,12 @@ class TagExtends extends AbstractTag
 	 *
 	 * @param array $tokens
 	 *
-	 * @throws \Liquid\Exception\FilesystemException
+	 * @throws \Liquid\Exception\MissingFilesystemException
 	 */
 	public function parse(array &$tokens)
 	{
 		if ($this->fileSystem === null) {
-			throw new FilesystemException("No file system");
+			throw new MissingFilesystemException("No file system");
 		}
 
 		// read the source of the template and create a new sub document

--- a/src/Liquid/Tag/TagFor.php
+++ b/src/Liquid/Tag/TagFor.php
@@ -12,9 +12,9 @@
 namespace Liquid\Tag;
 
 use Liquid\AbstractBlock;
+use Liquid\Exception\ParseException;
 use Liquid\Liquid;
 use Liquid\Context;
-use Liquid\LiquidException;
 use Liquid\FileSystem;
 use Liquid\Regexp;
 
@@ -62,7 +62,7 @@ class TagFor extends AbstractBlock
 	 * @param array $tokens
 	 * @param FileSystem $fileSystem
 	 *
-	 * @throws \Liquid\LiquidException
+	 * @throws \Liquid\Exception\ParseException
 	 */
 	public function __construct($markup, array &$tokens, FileSystem $fileSystem = null)
 	{
@@ -85,7 +85,7 @@ class TagFor extends AbstractBlock
 				$this->name = $syntaxRegexp->matches[1].'-digit';
 				$this->extractAttributes($markup);
 			} else {
-				throw new LiquidException("Syntax Error in 'for loop' - Valid syntax: for [item] in [collection]");
+				throw new ParseException("Syntax Error in 'for loop' - Valid syntax: for [item] in [collection]");
 			}
 		}
 	}

--- a/src/Liquid/Tag/TagIf.php
+++ b/src/Liquid/Tag/TagIf.php
@@ -13,8 +13,8 @@ namespace Liquid\Tag;
 
 use Liquid\Decision;
 use Liquid\Context;
+use Liquid\Exception\ParseException;
 use Liquid\Liquid;
-use Liquid\LiquidException;
 use Liquid\FileSystem;
 use Liquid\Regexp;
 
@@ -85,7 +85,7 @@ class TagIf extends Decision
 	 *
 	 * @param Context $context
 	 *
-	 * @throws \Liquid\LiquidException
+	 * @throws \Liquid\Exception\ParseException
 	 * @return string
 	 */
 	public function render(Context $context)
@@ -126,7 +126,7 @@ class TagIf extends Decision
 							'right' => $right
 						));
 					} else {
-						throw new LiquidException("Syntax Error in tag 'if' - Valid syntax: if [condition]");
+						throw new ParseException("Syntax Error in tag 'if' - Valid syntax: if [condition]");
 					}
 				}
 				if (count($logicalOperators)) {

--- a/src/Liquid/Tag/TagInclude.php
+++ b/src/Liquid/Tag/TagInclude.php
@@ -14,6 +14,8 @@ namespace Liquid\Tag;
 use Liquid\AbstractTag;
 use Liquid\Document;
 use Liquid\Context;
+use Liquid\Exception\FilesystemException;
+use Liquid\Exception\ParseException;
 use Liquid\Liquid;
 use Liquid\LiquidException;
 use Liquid\FileSystem;
@@ -72,14 +74,14 @@ class TagInclude extends AbstractTag
 	 * @param array $tokens
 	 * @param FileSystem $fileSystem
 	 *
-	 * @throws \Liquid\LiquidException
+	 * @throws \Liquid\Exception\ParseException
 	 */
 	public function __construct($markup, array &$tokens, FileSystem $fileSystem = null)
 	{
 		$regex = new Regexp('/("[^"]+"|\'[^\']+\'|[^\'"\s]+)(\s+(with|for)\s+(' . Liquid::get('QUOTED_FRAGMENT') . '+))?/');
 
 		if (!$regex->match($markup)) {
-			throw new LiquidException("Error in tag 'include' - Valid syntax: include '[template]' (with|for) [object|collection]");
+			throw new ParseException("Error in tag 'include' - Valid syntax: include '[template]' (with|for) [object|collection]");
 		}
 
 		$unquoted = (strpos($regex->matches[1], '"') === false && strpos($regex->matches[1], "'") === false);
@@ -109,12 +111,12 @@ class TagInclude extends AbstractTag
 	 *
 	 * @param array $tokens
 	 *
-	 * @throws \Liquid\LiquidException
+	 * @throws \Liquid\Exception\FilesystemException
 	 */
 	public function parse(array &$tokens)
 	{
 		if ($this->fileSystem === null) {
-			throw new LiquidException("No file system");
+			throw new FilesystemException("No file system");
 		}
 
 		// read the source of the template and create a new sub document

--- a/src/Liquid/Tag/TagInclude.php
+++ b/src/Liquid/Tag/TagInclude.php
@@ -14,7 +14,7 @@ namespace Liquid\Tag;
 use Liquid\AbstractTag;
 use Liquid\Document;
 use Liquid\Context;
-use Liquid\Exception\FilesystemException;
+use Liquid\Exception\MissingFilesystemException;
 use Liquid\Exception\ParseException;
 use Liquid\Liquid;
 use Liquid\LiquidException;
@@ -111,12 +111,12 @@ class TagInclude extends AbstractTag
 	 *
 	 * @param array $tokens
 	 *
-	 * @throws \Liquid\Exception\FilesystemException
+	 * @throws \Liquid\Exception\MissingFilesystemException
 	 */
 	public function parse(array &$tokens)
 	{
 		if ($this->fileSystem === null) {
-			throw new FilesystemException("No file system");
+			throw new MissingFilesystemException("No file system");
 		}
 
 		// read the source of the template and create a new sub document

--- a/src/Liquid/Tag/TagIncrement.php
+++ b/src/Liquid/Tag/TagIncrement.php
@@ -12,9 +12,9 @@
 namespace Liquid\Tag;
 
 use Liquid\AbstractTag;
+use Liquid\Exception\ParseException;
 use Liquid\Liquid;
 use Liquid\Context;
-use Liquid\LiquidException;
 use Liquid\FileSystem;
 use Liquid\Regexp;
 
@@ -43,7 +43,7 @@ class TagIncrement extends AbstractTag
 	 * @param array $tokens
 	 * @param FileSystem $fileSystem
 	 *
-	 * @throws \Liquid\LiquidException
+	 * @throws \Liquid\Exception\ParseException
 	 */
 	public function __construct($markup, array &$tokens, FileSystem $fileSystem = null)
 	{
@@ -52,7 +52,7 @@ class TagIncrement extends AbstractTag
 		if ($syntax->match($markup)) {
 			$this->toIncrement = $syntax->matches[0];
 		} else {
-			throw new LiquidException("Syntax Error in 'increment' - Valid syntax: increment [var]");
+			throw new ParseException("Syntax Error in 'increment' - Valid syntax: increment [var]");
 		}
 	}
 

--- a/src/Liquid/Tag/TagPaginate.php
+++ b/src/Liquid/Tag/TagPaginate.php
@@ -12,9 +12,9 @@
 namespace Liquid\Tag;
 
 use Liquid\AbstractBlock;
+use Liquid\Exception\ParseException;
 use Liquid\Liquid;
 use Liquid\Context;
-use Liquid\LiquidException;
 use Liquid\FileSystem;
 use Liquid\Regexp;
 
@@ -77,7 +77,7 @@ class TagPaginate extends AbstractBlock
 	 * @param array $tokens
 	 * @param FileSystem $fileSystem
 	 *
-	 * @throws \Liquid\LiquidException
+	 * @throws \Liquid\Exception\ParseException
 	 *
 	 */
 	public function __construct($markup, array &$tokens, FileSystem $fileSystem = null)
@@ -91,7 +91,7 @@ class TagPaginate extends AbstractBlock
 			$this->numberItems = $syntax->matches[2];
 			$this->extractAttributes($markup);
 		} else {
-			throw new LiquidException("Syntax Error - Valid syntax: paginate [collection] by [items]");
+			throw new ParseException("Syntax Error - Valid syntax: paginate [collection] by [items]");
 		}
 	}
 

--- a/src/Liquid/Tag/TagTablerow.php
+++ b/src/Liquid/Tag/TagTablerow.php
@@ -12,9 +12,10 @@
 namespace Liquid\Tag;
 
 use Liquid\AbstractBlock;
+use Liquid\Exception\ParseException;
+use Liquid\Exception\RenderException;
 use Liquid\Liquid;
 use Liquid\Context;
-use Liquid\LiquidException;
 use Liquid\FileSystem;
 use Liquid\Regexp;
 
@@ -51,7 +52,7 @@ class TagTablerow extends AbstractBlock
 	 * @param array $tokens
 	 * @param FileSystem $fileSystem
 	 *
-	 * @throws \Liquid\LiquidException
+	 * @throws \Liquid\Exception\ParseException
 	 */
 	public function __construct($markup, array &$tokens, FileSystem $fileSystem = null)
 	{
@@ -65,7 +66,7 @@ class TagTablerow extends AbstractBlock
 
 			$this->extractAttributes($markup);
 		} else {
-			throw new LiquidException("Syntax Error in 'table_row loop' - Valid syntax: table_row [item] in [collection] cols:3");
+			throw new ParseException("Syntax Error in 'table_row loop' - Valid syntax: table_row [item] in [collection] cols:3");
 		}
 	}
 
@@ -73,7 +74,7 @@ class TagTablerow extends AbstractBlock
 	 * Renders the current node
 	 *
 	 * @param Context $context
-	 *
+	 * @throws \Liquid\Exception\RenderException
 	 * @return string
 	 */
 	public function render(Context $context)
@@ -85,7 +86,7 @@ class TagTablerow extends AbstractBlock
 		}
 
 		if (!is_array($collection)) {
-			throw new LiquidException("Not an array");
+			throw new RenderException("Not an array");
 		}
 
 		// discard keys

--- a/src/Liquid/Template.php
+++ b/src/Liquid/Template.php
@@ -12,7 +12,7 @@
 namespace Liquid;
 
 use Liquid\Exception\CacheException;
-use Liquid\Exception\FilesystemException;
+use Liquid\Exception\MissingFilesystemException;
 
 /**
  * The Template class.
@@ -203,13 +203,13 @@ class Template
 	 * Parses the given template file
 	 *
 	 * @param string $templatePath
-	 * @throws \Liquid\Exception\FilesystemException
+	 * @throws \Liquid\Exception\MissingFilesystemException
 	 * @return Template
 	 */
 	public function parseFile($templatePath)
 	{
 		if (!$this->fileSystem) {
-			throw new FilesystemException("Could not load a template without an initialized file system");
+			throw new MissingFilesystemException("Could not load a template without an initialized file system");
 		}
 
 		return $this->parse($this->fileSystem->readTemplateFile($templatePath));

--- a/src/Liquid/Template.php
+++ b/src/Liquid/Template.php
@@ -11,6 +11,9 @@
 
 namespace Liquid;
 
+use Liquid\Exception\CacheException;
+use Liquid\Exception\FilesystemException;
+
 /**
  * The Template class.
  *
@@ -75,7 +78,7 @@ class Template
 	/**
 	 * @param array|Cache $cache
 	 *
-	 * @throws LiquidException
+	 * @throws \Liquid\Exception\CacheException
 	 */
 	public function setCache($cache)
 	{
@@ -84,7 +87,7 @@ class Template
 				$classname = '\Liquid\Cache\\' . ucwords($cache['cache']);
 				self::$cache = new $classname($cache);
 			} else {
-				throw new LiquidException('Invalid cache options!');
+				throw new CacheException('Invalid cache options!');
 			}
 		}
 
@@ -200,13 +203,13 @@ class Template
 	 * Parses the given template file
 	 *
 	 * @param string $templatePath
-	 *
+	 * @throws \Liquid\Exception\FilesystemException
 	 * @return Template
 	 */
 	public function parseFile($templatePath)
 	{
 		if (!$this->fileSystem) {
-			throw new LiquidException("Could not load a template without an initialized file system");
+			throw new FilesystemException("Could not load a template without an initialized file system");
 		}
 
 		return $this->parse($this->fileSystem->readTemplateFile($templatePath));

--- a/tests/Liquid/AbstractBlockTest.php
+++ b/tests/Liquid/AbstractBlockTest.php
@@ -16,7 +16,7 @@ use Liquid\TestCase;
 class AbstractBlockTest extends TestCase
 {
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 */
 	public function testUnterminatedBlockError()
 	{

--- a/tests/Liquid/Cache/FileTest.php
+++ b/tests/Liquid/Cache/FileTest.php
@@ -40,7 +40,7 @@ class FileTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\FilesystemException
 	 */
 	public function testConstructInvalidOptions()
 	{
@@ -48,7 +48,7 @@ class FileTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\FilesystemException
 	 */
 	public function testConstructNoSuchDirOrNotWritable()
 	{

--- a/tests/Liquid/CustomTagTest.php
+++ b/tests/Liquid/CustomTagTest.php
@@ -20,7 +20,7 @@ class TagFoo extends TagComment
 class CustomTagTest extends TestCase
 {
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 * @expectedExceptionMessage Unknown tag foo
 	 */
 	public function testUnknownTag()

--- a/tests/Liquid/FilterbankTest.php
+++ b/tests/Liquid/FilterbankTest.php
@@ -68,7 +68,7 @@ class FilterbankTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\WrongArgumentException
 	 */
 	public function testAddFilterNotObjectAndString()
 	{
@@ -76,7 +76,7 @@ class FilterbankTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\WrongArgumentException
 	 */
 	public function testAddFilterNoFunctionOrClass()
 	{

--- a/tests/Liquid/OutputTest.php
+++ b/tests/Liquid/OutputTest.php
@@ -149,7 +149,7 @@ class OutputTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 * @expectedExceptionMessage was not properly terminated
 	 */
 	public function testVariableWithANewLine()

--- a/tests/Liquid/Tag/TagAssignTest.php
+++ b/tests/Liquid/Tag/TagAssignTest.php
@@ -23,7 +23,7 @@ class TagAssignTest extends TestCase
 	/**
 	 * Tests the normal behavior of throwing an exception when the assignment is incorrect
 	 *
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 */
 	public function testInvalidAssign()
 	{

--- a/tests/Liquid/Tag/TagBlockTest.php
+++ b/tests/Liquid/Tag/TagBlockTest.php
@@ -16,7 +16,7 @@ use Liquid\TestCase;
 class TagBlockTest extends TestCase
 {
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 */
 	public function testSyntaxError()
 	{

--- a/tests/Liquid/Tag/TagCaptureTest.php
+++ b/tests/Liquid/Tag/TagCaptureTest.php
@@ -17,7 +17,7 @@ use Liquid\Template;
 class TagCaptureTest extends TestCase
 {
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 */
 	public function testInvalidSyntax()
 	{

--- a/tests/Liquid/Tag/TagCaseTest.php
+++ b/tests/Liquid/Tag/TagCaseTest.php
@@ -59,7 +59,7 @@ class TagCaseTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 */
 	public function testSyntaxErrorCase()
 	{
@@ -67,7 +67,7 @@ class TagCaseTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 */
 	public function testSyntaxErrorWhen()
 	{
@@ -75,7 +75,7 @@ class TagCaseTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 */
 	public function testSyntaxErrorEnd()
 	{
@@ -83,7 +83,7 @@ class TagCaseTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\RenderException
 	 */
 	public function testObject()
 	{

--- a/tests/Liquid/Tag/TagCycleTest.php
+++ b/tests/Liquid/Tag/TagCycleTest.php
@@ -17,7 +17,7 @@ use Liquid\Template;
 class TagCycleTest extends TestCase
 {
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 */
 	public function testInvalidSyntax()
 	{

--- a/tests/Liquid/Tag/TagExtendsTest.php
+++ b/tests/Liquid/Tag/TagExtendsTest.php
@@ -163,7 +163,7 @@ class TagExtendsTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 */
 	public function testInvalidSyntaxNoTemplateName()
 	{
@@ -172,7 +172,7 @@ class TagExtendsTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 */
 	public function testInvalidSyntaxNotQuotedTemplateName()
 	{
@@ -181,15 +181,18 @@ class TagExtendsTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 */
 	public function testInvalidSyntaxEmptyTemplateName()
 	{
 		$template = new Template();
+		$template->setFileSystem($this->fs);
 		$template->parse("{% extends '' %}");
 	}
 
 	/**
+	 * This needs fixing because it currently throws A FilesystemException (because the template filesystem is not defined in the test) instead of a ParseException which it should logically throw if the syntax is invalid.
+	 *
 	 * @expectedException \Liquid\LiquidException
 	 */
 	public function testInvalidSyntaxInvalidKeyword()

--- a/tests/Liquid/Tag/TagForTest.php
+++ b/tests/Liquid/Tag/TagForTest.php
@@ -17,7 +17,7 @@ use Liquid\Template;
 class TagForTest extends TestCase
 {
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 */
 	public function testForInvalidSyntax()
 	{

--- a/tests/Liquid/Tag/TagIfTest.php
+++ b/tests/Liquid/Tag/TagIfTest.php
@@ -217,7 +217,7 @@ class TagIfTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 * @expectedExceptionMessage if tag was never closed
 	 */
 	public function testSyntaxErrorNotClosed()
@@ -226,7 +226,7 @@ class TagIfTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 */
 	public function testSyntaxErrorEnd()
 	{
@@ -234,7 +234,7 @@ class TagIfTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\RenderException
 	 */
 	public function testInvalidOperator()
 	{
@@ -242,7 +242,7 @@ class TagIfTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\RenderException
 	 */
 	public function testIncomparable()
 	{
@@ -250,7 +250,7 @@ class TagIfTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 * @expectedExceptionMessage does not expect else tag
 	 */
 	public function testSyntaxErrorElse()
@@ -259,7 +259,7 @@ class TagIfTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 * @expectedExceptionMessage Unknown tag
 	 */
 	public function testSyntaxErrorUnknown()

--- a/tests/Liquid/Tag/TagIncludeTest.php
+++ b/tests/Liquid/Tag/TagIncludeTest.php
@@ -41,24 +41,30 @@ class TagIncludeTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 */
 	public function testInvalidSyntaxNoTemplateName()
 	{
 		$template = new Template();
+		$template->setFileSystem($this->fs);
 		$template->parse("{% include %}");
 	}
 
 	/**
+	 * This needs fixing because it currently throws A FilesystemException (because the template filesystem is not defined in the test) instead of a ParseException which it should logically throw if the syntax is invalid.
+	 *
 	 * @expectedException \Liquid\LiquidException
 	 */
 	public function testInvalidSyntaxInvalidKeyword()
 	{
+		$this->markTestIncomplete('Throws not because the syntax is invalid, but because there is no filesystem for the include');
 		$template = new Template();
 		$template->parse("{% include 'hello' no_keyword %}");
 	}
 
 	/**
+	 * This needs fixing because it currently throws A FilesystemException (because the template filesystem is not defined in the test) instead of a ParseException which it should logically throw if the syntax is invalid.
+	 *
 	 * @expectedException \Liquid\LiquidException
 	 */
 	public function testInvalidSyntaxNoObjectCollection()
@@ -132,7 +138,7 @@ class TagIncludeTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\RenderException
 	 * @expectedExceptionMessage Use index operator
 	 */
 	public function testIncludePassArrayWithoutIndex()

--- a/tests/Liquid/Tag/TagIncrementTest.php
+++ b/tests/Liquid/Tag/TagIncrementTest.php
@@ -16,7 +16,7 @@ use Liquid\TestCase;
 class TagIncrementTest extends TestCase
 {
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 */
 	public function testSyntaxError()
 	{

--- a/tests/Liquid/Tag/TagPaginateTest.php
+++ b/tests/Liquid/Tag/TagPaginateTest.php
@@ -37,7 +37,7 @@ class TagPaginateTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 */
 	public function testSyntaxErrorCase()
 	{

--- a/tests/Liquid/Tag/TagTablerowTest.php
+++ b/tests/Liquid/Tag/TagTablerowTest.php
@@ -47,7 +47,7 @@ class TagTablerowTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\ParseException
 	 */
 	public function testInvalidSyntax()
 	{
@@ -55,7 +55,7 @@ class TagTablerowTest extends TestCase
 	}
 
 	/**
-	 * @expectedException \Liquid\LiquidException
+	 * @expectedException \Liquid\Exception\RenderException
 	 */
 	public function testNotArray()
 	{


### PR DESCRIPTION
I have 6 different types of exceptions depending on the case : 
- CacheException for cache configuration errors. (extends Liquid\LiquiException)
- NotFoundException in case of file not found exception (extends FilesystemException)
- FilesystemException in case of errors with the filesystem. (extends Liquid\LiquiException)
- ParseException in case of parsing errors (extends Liquid\LiquiException)
- RenderException in case of render errors  (extends Liquid\LiquiException)
- WrongArgumentException for wrong arguments passed to filterBank::addFilter (extends Liquid\LiquiException)

Let me know what you think.

Resolves https://github.com/kalimatas/php-liquid/issues/74

- [x] I've run the tests with `vendor/bin/phpunit`
- [x] None of the tests were found failing
- [x] I've seen the coverage report at `build/coverage/index.html`
- [x] Not a single line left uncovered by tests
- [x] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`
- [x] Hotfix-type commits were squashed with `git rebase -i` or `git commit --amend`
- [x] All my work wasn't smushed into one large commit without necessity
