### PR TITLE
Easy filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,20 @@ If you render the same template over and over for at least a dozen of times, the
 
 You should probably extend `Liquid\Template` to initialize everything you do with `Liquid::set` in one place.
 
+### Custom filters
+
+Adding filters has never been easier.
+
+	$template = new Template();
+	$template->registerFilter('absolute_url', function ($arg) {
+	    return "https://www.example.com$arg";
+	});
+	$template->parse("{{ my_url | absolute_url }}");
+	echo $template->render(array(
+	    'my_url' => '/test'
+	));
+	// expect: https://www.example.com/test
+
 ## Requirements
 
  * PHP 5.6+

--- a/examples/filters.php
+++ b/examples/filters.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Liquid package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package Liquid
+ */
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Liquid\Liquid;
+use Liquid\Template;
+
+$template = new Template();
+$template->registerFilter('absolute_url', function ($arg) {
+	return "https://www.example.com$arg";
+});
+$template->parse("{{ my_url | absolute_url }}");
+echo $template->render(array(
+	'my_url' => '/test'
+));
+// expect: https://www.example.com/test

--- a/src/Liquid/AbstractBlock.php
+++ b/src/Liquid/AbstractBlock.php
@@ -19,6 +19,8 @@ use Liquid\Exception\RenderException;
  */
 class AbstractBlock extends AbstractTag
 {
+	const TAG_PREFIX = '\Liquid\Tag\Tag';
+
 	/**
 	 * @var AbstractTag[]
 	 */
@@ -65,7 +67,7 @@ class AbstractBlock extends AbstractTag
 					if (array_key_exists($tagRegexp->matches[1], $tags)) {
 						$tagName = $tags[$tagRegexp->matches[1]];
 					} else {
-						$tagName = '\Liquid\Tag\Tag' . ucwords($tagRegexp->matches[1]);
+						$tagName = self::TAG_PREFIX . ucwords($tagRegexp->matches[1]);
 						$tagName = (class_exists($tagName) === true) ? $tagName : null;
 					}
 

--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -64,9 +64,9 @@ class Context
 	 *
 	 * @param mixed $filter
 	 */
-	public function addFilters($filter)
+	public function addFilters($filter, callable $callback = null)
 	{
-		$this->filterbank->addFilter($filter);
+		$this->filterbank->addFilter($filter, $callback);
 	}
 
 	/**

--- a/src/Liquid/Filterbank.php
+++ b/src/Liquid/Filterbank.php
@@ -49,8 +49,8 @@ class Filterbank
 	{
 		$this->context = $context;
 
-		$this->addFilter('\Liquid\StandardFilters');
-		$this->addFilter('\Liquid\CustomFilters');
+		$this->addFilter(\Liquid\StandardFilters::class);
+		$this->addFilter(\Liquid\CustomFilters::class);
 	}
 
 	/**

--- a/src/Liquid/Template.php
+++ b/src/Liquid/Template.php
@@ -82,7 +82,7 @@ class Template
 	 *
 	 * @throws \Liquid\Exception\CacheException
 	 */
-	public function setCache($cache)
+	public static function setCache($cache)
 	{
 		if (is_array($cache)) {
 			if (isset($cache['cache']) && class_exists($classname = self::CLASS_PREFIX . ucwords($cache['cache']))) {

--- a/src/Liquid/Template.php
+++ b/src/Liquid/Template.php
@@ -141,9 +141,14 @@ class Template
 	 *
 	 * @param string $filter
 	 */
-	public function registerFilter($filter)
+	public function registerFilter($filter, callable $callback = null)
 	{
-		$this->filters[] = $filter;
+		// Store callback for later use
+		if ($callback) {
+			$this->filters[] = [$filter, $callback];
+		} else {
+			$this->filters[] = $filter;
+		}
 	}
 
 	/**
@@ -238,7 +243,12 @@ class Template
 		}
 
 		foreach ($this->filters as $filter) {
-			$context->addFilters($filter);
+			if (is_array($filter)) {
+				// Unpack a callback saved as second argument
+				$context->addFilters(...$filter);
+			} else {
+				$context->addFilters($filter);
+			}
 		}
 
 		return $this->root->render($context);

--- a/src/Liquid/Template.php
+++ b/src/Liquid/Template.php
@@ -25,6 +25,8 @@ use Liquid\Exception\MissingFilesystemException;
  */
 class Template
 {
+	const CLASS_PREFIX = '\Liquid\Cache\\';
+
 	/**
 	 * @var Document The root of the node tree
 	 */
@@ -83,8 +85,7 @@ class Template
 	public function setCache($cache)
 	{
 		if (is_array($cache)) {
-			if (isset($cache['cache']) && class_exists('\Liquid\Cache\\' . ucwords($cache['cache']))) {
-				$classname = '\Liquid\Cache\\' . ucwords($cache['cache']);
+			if (isset($cache['cache']) && class_exists($classname = self::CLASS_PREFIX . ucwords($cache['cache']))) {
 				self::$cache = new $classname($cache);
 			} else {
 				throw new CacheException('Invalid cache options!');

--- a/tests/Liquid/Cache/ApcTest.php
+++ b/tests/Liquid/Cache/ApcTest.php
@@ -12,7 +12,6 @@
 namespace Liquid\Cache;
 
 use Liquid\TestCase;
-use \Liquid\Cache\Apc;
 
 class ApcTest extends TestCase
 {

--- a/tests/Liquid/Cache/LocalTest.php
+++ b/tests/Liquid/Cache/LocalTest.php
@@ -12,7 +12,6 @@
 namespace Liquid\Cache;
 
 use Liquid\TestCase;
-use \Liquid\Cache\Local;
 
 class LocalTest extends TestCase
 {

--- a/tests/Liquid/ContextTest.php
+++ b/tests/Liquid/ContextTest.php
@@ -304,6 +304,17 @@ class ContextTest extends TestCase
 		$this->assertEquals('Local test', $template->render(array(), new LocalFilter()));
 	}
 
+	public function testCallbackFilter()
+	{
+		$template = new Template();
+		$template->registerFilter('foo', function ($arg) {
+			return "Foo $arg";
+		});
+
+		$template->parse("{{'test' | foo }}");
+		$this->assertEquals('Foo test', $template->render());
+	}
+
 	public function testAddItemInOuterScope()
 	{
 		$this->context->set('test', 'test');

--- a/tests/Liquid/FilterbankTest.php
+++ b/tests/Liquid/FilterbankTest.php
@@ -51,6 +51,14 @@ class ClassFilter
 
 namespace Liquid {
 
+class NamespacedClassFilter
+{
+	public static function static_test2()
+	{
+		return "good";
+	}
+}
+
 class FilterbankTest extends TestCase
 {
 	/** @var FilterBank */
@@ -98,6 +106,17 @@ class FilterbankTest extends TestCase
 		$this->context->set('var', 1000);
 		$this->context->addFilters('functionFilter');
 		$this->assertEquals('worked', $var->render($this->context));
+	}
+
+	/**
+	 * Test using a namespaced static class
+	 */
+	public function testNamespacedStaticClassFilter()
+	{
+		$var = new Variable('var | static_test2');
+		$this->context->set('var', 1000);
+		$this->context->addFilters(NamespacedClassFilter::class);
+		$this->assertEquals('good', $var->render($this->context));
 	}
 
 	/**

--- a/tests/Liquid/FilterbankTest.php
+++ b/tests/Liquid/FilterbankTest.php
@@ -107,8 +107,19 @@ class FilterbankTest extends TestCase
 	{
 		$var = new Variable('var | static_test');
 		$this->context->set('var', 1000);
-		$this->context->addFilters('\ClassFilter');
+		$this->context->addFilters(\ClassFilter::class);
 		$this->assertEquals('worked', $var->render($this->context));
+	}
+
+	/**
+	 * Test with instance method on a static class
+	 */
+	public function testStaticMixedClassFilter()
+	{
+		$var = new Variable('var | instance_test_one');
+		$this->context->set('var', 'foo');
+		$this->context->addFilters(\ClassFilter::class);
+		$this->assertEquals('foo', $var->render($this->context));
 	}
 
 	/**
@@ -124,6 +135,9 @@ class FilterbankTest extends TestCase
 
 		$var = new Variable('var | instance_test_two');
 		$this->assertEquals('set', $var->render($this->context));
+
+		$var = new Variable('var | static_test');
+		$this->assertEquals('worked', $var->render($this->context));
 	}
 }
 

--- a/tests/Liquid/FilterbankTest.php
+++ b/tests/Liquid/FilterbankTest.php
@@ -53,9 +53,9 @@ namespace Liquid {
 
 class NamespacedClassFilter
 {
-	public static function static_test2()
+	public static function static_test2($var)
 	{
-		return "good";
+		return "good {$var}";
 	}
 }
 
@@ -116,7 +116,7 @@ class FilterbankTest extends TestCase
 		$var = new Variable('var | static_test2');
 		$this->context->set('var', 1000);
 		$this->context->addFilters(NamespacedClassFilter::class);
-		$this->assertEquals('good', $var->render($this->context));
+		$this->assertEquals('good 1000', $var->render($this->context));
 	}
 
 	/**

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -1075,8 +1075,8 @@ class StandardFiltersTest extends TestCase
 	{
 		$var = new Variable('var | money ');
 		$this->context->set('var', 1000);
-		$this->context->addFilters(new MoneyFilter(), 'money');
-		$this->context->addFilters(new CanadianMoneyFilter(), 'money');
+		$this->context->addFilters(new MoneyFilter());
+		$this->context->addFilters(new CanadianMoneyFilter());
 		$this->assertEquals(' 1000$ CAD ', $var->render($this->context));
 	}
 

--- a/tests/Liquid/Tag/TagExtendsTest.php
+++ b/tests/Liquid/Tag/TagExtendsTest.php
@@ -14,7 +14,6 @@ namespace Liquid\Tag;
 use Liquid\TestCase;
 use Liquid\Template;
 use Liquid\Cache\Local;
-use Liquid\FileSystem\Virtual;
 use Liquid\TestFileSystem;
 
 /**

--- a/tests/Liquid/Tag/TagExtendsTest.php
+++ b/tests/Liquid/Tag/TagExtendsTest.php
@@ -172,11 +172,22 @@ class TagExtendsTest extends TestCase
 
 	/**
 	 * @expectedException \Liquid\Exception\ParseException
+	 * @expectedExceptionMessage Error in tag
 	 */
 	public function testInvalidSyntaxNotQuotedTemplateName()
 	{
 		$template = new Template();
 		$template->parse("{% extends base %}");
+	}
+
+	/**
+	 * @expectedException \Liquid\Exception\MissingFilesystemException
+	 * @expectedExceptionMessage No file system
+	 */
+	public function testMissingFilesystem()
+	{
+		$template = new Template();
+		$template->parse("{% extends 'base' %}");
 	}
 
 	/**

--- a/tests/Liquid/Tag/TagExtendsTest.php
+++ b/tests/Liquid/Tag/TagExtendsTest.php
@@ -189,14 +189,12 @@ class TagExtendsTest extends TestCase
 		$template->parse("{% extends '' %}");
 	}
 
-	/**
-	 * This needs fixing because it currently throws A FilesystemException (because the template filesystem is not defined in the test) instead of a ParseException which it should logically throw if the syntax is invalid.
-	 *
-	 * @expectedException \Liquid\LiquidException
-	 */
 	public function testInvalidSyntaxInvalidKeyword()
 	{
 		$template = new Template();
+		$template->setFileSystem($this->fs);
 		$template->parse("{% extends 'base' nothing-should-be-here %}");
+
+		$this->markTestIncomplete("Exception is expected here");
 	}
 }

--- a/tests/Liquid/Tag/TagIncludeTest.php
+++ b/tests/Liquid/Tag/TagIncludeTest.php
@@ -49,27 +49,22 @@ class TagIncludeTest extends TestCase
 		$template->parse("{% include %}");
 	}
 
-	/**
-	 * This needs fixing because it currently throws A FilesystemException (because the template filesystem is not defined in the test) instead of a ParseException which it should logically throw if the syntax is invalid.
-	 *
-	 * @expectedException \Liquid\LiquidException
-	 */
 	public function testInvalidSyntaxInvalidKeyword()
 	{
-		$this->markTestIncomplete('Throws not because the syntax is invalid, but because there is no filesystem for the include');
 		$template = new Template();
+		$template->setFileSystem($this->fs);
 		$template->parse("{% include 'hello' no_keyword %}");
+
+		$this->markTestIncomplete("Exception is expected here");
 	}
 
-	/**
-	 * This needs fixing because it currently throws A FilesystemException (because the template filesystem is not defined in the test) instead of a ParseException which it should logically throw if the syntax is invalid.
-	 *
-	 * @expectedException \Liquid\LiquidException
-	 */
 	public function testInvalidSyntaxNoObjectCollection()
 	{
 		$template = new Template();
+		$template->setFileSystem($this->fs);
 		$template->parse("{% include 'hello' with %}");
+
+		$this->markTestIncomplete("Exception is expected here");
 	}
 
 	public function testIncludeTag()

--- a/tests/Liquid/Tag/TagIncludeTest.php
+++ b/tests/Liquid/Tag/TagIncludeTest.php
@@ -15,7 +15,6 @@ use Liquid\TestCase;
 use Liquid\Template;
 use Liquid\Liquid;
 use Liquid\Cache\Local;
-use Liquid\FileSystem\Virtual;
 use Liquid\TestFileSystem;
 
 class TagIncludeTest extends TestCase

--- a/tests/Liquid/Tag/TagIncludeTest.php
+++ b/tests/Liquid/Tag/TagIncludeTest.php
@@ -49,6 +49,16 @@ class TagIncludeTest extends TestCase
 		$template->parse("{% include %}");
 	}
 
+	/**
+	 * @expectedException \Liquid\Exception\MissingFilesystemException
+	 * @expectedExceptionMessage No file system
+	 */
+	public function testMissingFilesystem()
+	{
+		$template = new Template();
+		$template->parse("{% include 'hello' %}");
+	}
+
 	public function testInvalidSyntaxInvalidKeyword()
 	{
 		$template = new Template();

--- a/tests/Liquid/Tag/TagIncludeTest.php
+++ b/tests/Liquid/Tag/TagIncludeTest.php
@@ -41,6 +41,7 @@ class TagIncludeTest extends TestCase
 
 	/**
 	 * @expectedException \Liquid\Exception\ParseException
+	 * @expectedExceptionMessage Error in tag
 	 */
 	public function testInvalidSyntaxNoTemplateName()
 	{

--- a/tests/Liquid/TemplateTest.php
+++ b/tests/Liquid/TemplateTest.php
@@ -55,7 +55,7 @@ class TemplateTest extends TestCase
 	{
 		$template = new Template();
 		$template->setCache(array('cache' => 'file', 'cache_dir' => $this->cacheDir));
-		$this->assertInstanceOf('\Liquid\Cache\File', $template::getCache());
+		$this->assertInstanceOf(\Liquid\Cache\File::class, $template::getCache());
 	}
 
 	public function testSetCacheThroughCacheObject()
@@ -106,7 +106,7 @@ class TemplateTest extends TestCase
 		$nodelist = $template->getRoot()->getNodelist();
 
 		$this->assertEquals(2, count($nodelist));
-		$this->assertInstanceOf('\Liquid\Variable', $nodelist[0]);
+		$this->assertInstanceOf(\Liquid\Variable::class, $nodelist[0]);
 		$this->assertInternalType('string', $nodelist[1]);
 	}
 
@@ -119,7 +119,7 @@ class TemplateTest extends TestCase
 
 		$this->assertEquals(2, count($nodelist));
 		$this->assertInternalType('string', $nodelist[0]);
-		$this->assertInstanceOf('\Liquid\Variable', $nodelist[1]);
+		$this->assertInstanceOf(\Liquid\Variable::class, $nodelist[1]);
 	}
 
 	public function testVariableMiddle()
@@ -131,7 +131,7 @@ class TemplateTest extends TestCase
 
 		$this->assertEquals(3, count($nodelist));
 		$this->assertInternalType('string', $nodelist[0]);
-		$this->assertInstanceOf('\Liquid\Variable', $nodelist[1]);
+		$this->assertInstanceOf(\Liquid\Variable::class, $nodelist[1]);
 		$this->assertInternalType('string', $nodelist[2]);
 	}
 
@@ -144,11 +144,11 @@ class TemplateTest extends TestCase
 
 		$this->assertEquals(7, count($nodelist));
 		$this->assertInternalType('string', $nodelist[0]);
-		$this->assertInstanceOf('\Liquid\Variable', $nodelist[1]);
+		$this->assertInstanceOf(\Liquid\Variable::class, $nodelist[1]);
 		$this->assertInternalType('string', $nodelist[2]);
-		$this->assertInstanceOf('\Liquid\Variable', $nodelist[3]);
+		$this->assertInstanceOf(\Liquid\Variable::class, $nodelist[3]);
 		$this->assertInternalType('string', $nodelist[4]);
-		$this->assertInstanceOf('\Liquid\Variable', $nodelist[5]);
+		$this->assertInstanceOf(\Liquid\Variable::class, $nodelist[5]);
 		$this->assertInternalType('string', $nodelist[6]);
 	}
 
@@ -161,7 +161,7 @@ class TemplateTest extends TestCase
 
 		$this->assertEquals(3, count($nodelist));
 		$this->assertInternalType('string', $nodelist[0]);
-		$this->assertInstanceOf('\Liquid\Tag\TagComment', $nodelist[1]);
+		$this->assertInstanceOf(\Liquid\Tag\TagComment::class, $nodelist[1]);
 		$this->assertInternalType('string', $nodelist[2]);
 	}
 }

--- a/tests/Liquid/TestCase.php
+++ b/tests/Liquid/TestCase.php
@@ -44,6 +44,8 @@ class TestCase extends \PHPUnit_Framework_TestCase
 		foreach ($defaultConfig as $configKey => $configValue) {
 			Liquid::set($configKey, $configValue);
 		}
+
+		Template::setCache(null);
 	}
 
 	/**


### PR DESCRIPTION
Just like that:

	$template = new Template();
	$template->registerFilter('absolute_url', function ($arg) {
	    return "https://www.example.com$arg";
	});
	$template->parse("{{ my_url | absolute_url }}");
	echo $template->render(array(
	    'my_url' => '/test'
	));
	// expect: https://www.example.com/test


- [x] I've run the tests with `vendor/bin/phpunit`
- [x] None of the tests were found failing
- [x] I've seen the coverage report at `build/coverage/index.html`
- [x] Not a single line left uncovered by tests
- [x] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`
- [x] Hotfix-type commits were squashed with `git rebase -i` or `git commit --amend`
- [x] All my work wasn't smushed into one large commit without necessity
