### PR TITLE
`escape` and `escape_once` should do their job at all costs

### DIFF
--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -351,7 +351,7 @@ class Context
 
 		// lastly, try to get an embedded value of an object
 		// value could be of any type, not just string, so we have to do this
-		// conversion here, not laster in AbstractBlock::renderAll
+		// conversion here, not later in AbstractBlock::renderAll
 		if (method_exists($object, 'toLiquid')) {
 			$object = $object->toLiquid();
 		}

--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -535,7 +535,18 @@ class StandardFilters
 
 		return $input;
 	}
-	
+
+	/**
+	 * Explicit string conversion.
+	 *
+	 * @param mixed $input
+	 *
+	 * @return string
+	 */
+	public static function string($input)
+	{
+		return strval($input);
+	}
 
 	/**
 	 * Split input string into an array of substrings separated by given pattern.

--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -145,7 +145,12 @@ class StandardFilters
 	 */
 	public static function escape($input)
 	{
-		return is_string($input) ? htmlentities($input, ENT_QUOTES) : $input;
+		// Arrays are taken care down the stack with an error
+		if (is_array($input)) {
+			return $input;
+		}
+
+		return htmlentities($input, ENT_QUOTES);
 	}
 
 
@@ -158,7 +163,12 @@ class StandardFilters
 	 */
 	public static function escape_once($input)
 	{
-		return is_string($input) ? htmlentities($input, ENT_QUOTES, null, false) : $input;
+		// Arrays are taken care down the stack with an error
+		if (is_array($input)) {
+			return $input;
+		}
+
+		return htmlentities($input, ENT_QUOTES, null, false);
 	}
 
 

--- a/tests/Liquid/EscapeByDefaultTest.php
+++ b/tests/Liquid/EscapeByDefaultTest.php
@@ -11,6 +11,21 @@
 
 namespace Liquid;
 
+class ObjectWithToString
+{
+	private $string = '';
+
+	public function __construct($string)
+	{
+		$this->string = $string;
+	}
+
+	public function __toString()
+	{
+		return $this->string;
+	}
+}
+
 class EscapeByDefaultTest extends TestCase
 {
 	const XSS = "<script>alert()</script>";
@@ -82,6 +97,17 @@ class EscapeByDefaultTest extends TestCase
 		$text = "{{ xss | newline_to_br }}";
 		$expected = self::XSS."<br />\n".self::XSS;
 		$this->assertTemplateResult($expected, $text, array('xss' => self::XSS."\n".self::XSS));
+	}
+
+	public function testToStringEscape()
+	{
+		$this->assertTemplateResult(self::XSS_FAILED, "{{ xss | escape }}", array('xss' => new ObjectWithToString(self::XSS)));
+	}
+
+	public function testToStringEscapeDefault()
+	{
+		Liquid::set('ESCAPE_BY_DEFAULT', true);
+		$this->assertTemplateResult(self::XSS_FAILED, "{{ xss }}", array('xss' => new ObjectWithToString(self::XSS)));
 	}
 
 	/** System default value for the escape flag */

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -45,6 +45,11 @@ class SizeClass
 	{
 		return self::SIZE;
 	}
+
+	public function __toString()
+	{
+		return "forty two";
+	}
 }
 
 
@@ -745,6 +750,24 @@ class StandardFiltersTest extends TestCase
 
 		foreach ($data as $item) {
 			$this->assertEquals($item[1], StandardFilters::last($item[0]));
+		}
+	}
+
+	public function testString()
+	{
+		$data = array(
+				array(
+						1,
+						'1',
+				),
+				array(
+						new SizeClass(),
+						"forty two",
+				),
+		);
+
+		foreach ($data as $item) {
+			$this->assertEquals($item[1], StandardFilters::string($item[0]));
 		}
 	}
 

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -177,6 +177,8 @@ class StandardFiltersTest extends TestCase
 		foreach ($data as $element => $expected) {
 			$this->assertEquals($expected, StandardFilters::escape($element));
 		}
+
+		$this->assertSame(array(1), StandardFilters::escape(array(1)));
 	}
 
 	public function testEscapeOnce()
@@ -191,6 +193,8 @@ class StandardFiltersTest extends TestCase
 		foreach ($data as $element => $expected) {
 			$this->assertEquals($expected, StandardFilters::escape_once($element));
 		}
+
+		$this->assertSame(array(1), StandardFilters::escape_once(array(1)));
 	}
 
 	public function testStripNewLines()


### PR DESCRIPTION
`escape` and `escape_once` should do their job at all costs by casting objects to strings when needed.

- [x] I've run the tests with `vendor/bin/phpunit`
- [x] None of the tests were found failing
- [x] I've seen the coverage report at `build/coverage/index.html`
- [x] Not a single line left uncovered by tests
- [x] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`
- [x] Hotfix-type commits were squashed with `git rebase -i` or `git commit --amend`
- [x] All my work wasn't smushed into one large commit without necessity
