### PR TITLE
Allow dashes in filenames (LocalFileSystem)

### DIFF
--- a/src/Liquid/FileSystem/Local.php
+++ b/src/Liquid/FileSystem/Local.php
@@ -80,8 +80,8 @@ class Local implements FileSystem
 		}
 
 		$nameRegex = Liquid::get('INCLUDE_ALLOW_EXT')
-		? new Regexp('/^[^.\/][a-zA-Z0-9_\.\/]+$/')
-		: new Regexp('/^[^.\/][a-zA-Z0-9_\/]+$/');
+		? new Regexp('/^[^.\/][a-zA-Z0-9_\.\/-]+$/')
+		: new Regexp('/^[^.\/][a-zA-Z0-9_\/-]+$/');
 
 		if (!$nameRegex->match($templatePath)) {
 			throw new ParseException("Illegal template name '$templatePath'");


### PR DESCRIPTION
Simple fix to allow dashes in filenames, example:

{% include my-partial %}

Before: ParserException Illegal template name
After: Happy user.

- [ v ] I've run the tests with `vendor/bin/phpunit`
