### PR TITLE
Context: return null for missing properties, like we do for arrays.

### DIFF
--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -340,6 +340,11 @@ class Context
 				continue;
 			}
 
+			// Inexistent property is a null, PHP-speak
+			if (!property_exists($object, $nextPartName)) {
+				return null;
+			}
+
 			// then try a property (independent of accessibility)
 			if (property_exists($object, $nextPartName)) {
 				$object = $object->$nextPartName;

--- a/tests/Liquid/ContextTest.php
+++ b/tests/Liquid/ContextTest.php
@@ -192,6 +192,7 @@ class ContextTest extends TestCase
 		$this->context->set('test', new NoToLiquid());
 		$this->assertEquals(42, $this->context->get('test.answer'));
 		$this->assertEquals(1, $this->context->get('test.count'));
+		$this->assertEquals(null, $this->context->get('test.invalid'));
 		$this->assertEquals("forty two", $this->context->get('test'));
 		$this->assertEquals("example", $this->context->get('test.name'));
 	}


### PR DESCRIPTION
Fixes #101