### PR TITLE
Don't add '__construct' as filter!

### DIFF
--- a/src/Liquid/Filterbank.php
+++ b/src/Liquid/Filterbank.php
@@ -98,6 +98,9 @@ class Filterbank
 
 		// Then register all public static and not methods as filters
 		foreach (get_class_methods($filter) as $method) {
+			if (strtolower($method) === '__construct') {
+				continue;
+			}
 			$this->methodMap[$method] = $className;
 		}
 

--- a/tests/Liquid/FilterbankTest.php
+++ b/tests/Liquid/FilterbankTest.php
@@ -175,6 +175,27 @@ class FilterbankTest extends TestCase
 		$this->assertEquals('1000', $var->render($this->context));
 	}
 
+	public function testObjectFilterDontCallConstruct()
+	{
+		$this->context->set('var', 1000);
+		$this->context->addFilters(new \ClassFilter());
+
+		$filterbankReflectionClass = new \ReflectionClass(Context::class);
+		$methodMapProperty = $filterbankReflectionClass->getProperty('filterbank');
+		$methodMapProperty->setAccessible(true);
+		$filterbank = $methodMapProperty->getValue($this->context);
+
+		$filterbankReflectionClass = new \ReflectionClass(Filterbank::class);
+		$methodMapProperty = $filterbankReflectionClass->getProperty('methodMap');
+		$methodMapProperty->setAccessible(true);
+		$methodMap = $methodMapProperty->getValue($filterbank);
+
+		$this->assertArrayNotHasKey('__construct', $methodMap);
+
+		$var = new Variable('var | __construct');
+		$this->assertEquals('1000', $var->render($this->context));
+	}
+
 	public function testCallbackFilter()
 	{
 		$var = new Variable('var | my_callback');

--- a/tests/Liquid/FilterbankTest.php
+++ b/tests/Liquid/FilterbankTest.php
@@ -30,6 +30,10 @@ class ClassFilter
 {
 	private $variable = 'not set';
 
+	public function __construct()
+	{
+	}
+
 	public static function static_test()
 	{
 		return "worked";
@@ -166,6 +170,9 @@ class FilterbankTest extends TestCase
 
 		$var = new Variable('var | static_test');
 		$this->assertEquals('worked', $var->render($this->context));
+
+		$var = new Variable('var | __construct');
+		$this->assertEquals('1000', $var->render($this->context));
 	}
 
 	public function testCallbackFilter()


### PR DESCRIPTION
If `addFilter()` was given an object than `__construct()' method would be added if exists and something like {{ var | __construct }} would be possible. 

My PR would be fix this.

- [x] I've run the tests with `vendor/bin/phpunit`
- [x] None of the tests were found failing
- [x] I've seen the coverage report at `build/coverage/index.html`
- [x] Not a single line left uncovered by tests
- [x] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`
