### PR TITLE
add support for content ticks

### DIFF
--- a/src/Liquid/AbstractBlock.php
+++ b/src/Liquid/AbstractBlock.php
@@ -135,6 +135,8 @@ class AbstractBlock extends AbstractTag
 			if (isset($context->registers['continue'])) {
 				break;
 			}
+
+			$context->tick();
 		}
 
 		return $result;

--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -56,6 +56,7 @@ class Context
 	 *
 	 * @param array $assigns
 	 * @param array $registers
+	 * @param callable $tickFunction
 	 */
 	public function __construct(array $assigns = array(), array $registers = array(), callable $tickFunction = null)
 	{

--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -44,11 +44,11 @@ class Context
 	 */
 	public $environments = array();
 
-    /**
-     * Called "sometimes" while rendering. For example to abort the execution of a rendering.
-     *
-     * @var null|callable
-     */
+	/**
+	 * Called "sometimes" while rendering. For example to abort the execution of a rendering.
+	 *
+	 * @var null|callable
+	 */
 	protected $tickFunction = null;
 
 	/**
@@ -393,12 +393,12 @@ class Context
 	}
 
 	public function tick()
-    {
-        if ($this->tickFunction === null) {
-            return;
-        }
+	{
+		if ($this->tickFunction === null) {
+			return;
+		}
 
-        $tickFunction = $this->tickFunction;
-        $tickFunction($this);
-    }
+		$tickFunction = $this->tickFunction;
+		$tickFunction($this);
+	}
 }

--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -44,19 +44,27 @@ class Context
 	 */
 	public $environments = array();
 
+    /**
+     * Called "sometimes" while rendering. For example to abort the execution of a rendering.
+     *
+     * @var null|callable
+     */
+	protected $tickFunction = null;
+
 	/**
 	 * Constructor
 	 *
 	 * @param array $assigns
 	 * @param array $registers
 	 */
-	public function __construct(array $assigns = array(), array $registers = array())
+	public function __construct(array $assigns = array(), array $registers = array(), callable $tickFunction = null)
 	{
 		$this->assigns = array($assigns);
 		$this->registers = $registers;
 		$this->filterbank = new Filterbank($this);
 		// first empty array serves as source for overrides, e.g. as in TagDecrement
 		$this->environments = array(array(), $_SERVER);
+		$this->tickFunction = $tickFunction;
 	}
 
 	/**
@@ -383,4 +391,14 @@ class Context
 
 		return $object;
 	}
+
+	public function tick()
+    {
+        if ($this->tickFunction === null) {
+            return;
+        }
+
+        $tickFunction = $this->tickFunction;
+        $tickFunction($this);
+    }
 }

--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -49,7 +49,7 @@ class Context
 	 *
 	 * @var null|callable
 	 */
-	protected $tickFunction = null;
+	private $tickFunction = null;
 
 	/**
 	 * Constructor

--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -56,15 +56,23 @@ class Context
 	 *
 	 * @param array $assigns
 	 * @param array $registers
-	 * @param callable $tickFunction
 	 */
-	public function __construct(array $assigns = array(), array $registers = array(), callable $tickFunction = null)
+	public function __construct(array $assigns = array(), array $registers = array())
 	{
 		$this->assigns = array($assigns);
 		$this->registers = $registers;
 		$this->filterbank = new Filterbank($this);
 		// first empty array serves as source for overrides, e.g. as in TagDecrement
 		$this->environments = array(array(), $_SERVER);
+	}
+
+	/**
+	 * Sets a tick function, this function is called sometimes while liquid is rendering a template.
+	 *
+	 * @param callable $tickFunction
+	 */
+	public function setTickFunction(callable $tickFunction)
+	{
 		$this->tickFunction = $tickFunction;
 	}
 

--- a/src/Liquid/Template.php
+++ b/src/Liquid/Template.php
@@ -43,6 +43,11 @@ class Template
 	private $filters = array();
 
 	/**
+	 * @var callable|null Called "sometimes" while rendering. For example to abort the execution of a rendering.
+	 */
+	private $tickFunction = null;
+
+	/**
 	 * @var array Custom tags
 	 */
 	private static $tags = array();
@@ -151,6 +156,11 @@ class Template
 		}
 	}
 
+	public function setTickFunction(callable $tickFunction)
+	{
+		$this->tickFunction = $tickFunction;
+	}
+
 	/**
 	 * Tokenizes the given source string
 	 *
@@ -233,6 +243,10 @@ class Template
 	public function render(array $assigns = array(), $filters = null, array $registers = array())
 	{
 		$context = new Context($assigns, $registers);
+
+		if ($this->tickFunction) {
+			$context->setTickFunction($this->tickFunction);
+		}
 
 		if (!is_null($filters)) {
 			if (is_array($filters)) {

--- a/src/Liquid/Template.php
+++ b/src/Liquid/Template.php
@@ -227,6 +227,7 @@ class Template
 	 * @param array $assigns an array of values for the template
 	 * @param array $filters additional filters for the template
 	 * @param array $registers additional registers for the template
+	 * @param array $tickFunction tick function
 	 *
 	 * @return string
 	 */

--- a/src/Liquid/Template.php
+++ b/src/Liquid/Template.php
@@ -227,13 +227,12 @@ class Template
 	 * @param array $assigns an array of values for the template
 	 * @param array $filters additional filters for the template
 	 * @param array $registers additional registers for the template
-	 * @param array $tickFunction tick function
 	 *
 	 * @return string
 	 */
-	public function render(array $assigns = array(), $filters = null, array $registers = array(), callable $tickFunction = null)
+	public function render(array $assigns = array(), $filters = null, array $registers = array())
 	{
-		$context = new Context($assigns, $registers, $tickFunction);
+		$context = new Context($assigns, $registers);
 
 		if (!is_null($filters)) {
 			if (is_array($filters)) {

--- a/src/Liquid/Template.php
+++ b/src/Liquid/Template.php
@@ -230,9 +230,9 @@ class Template
 	 *
 	 * @return string
 	 */
-	public function render(array $assigns = array(), $filters = null, array $registers = array())
+	public function render(array $assigns = array(), $filters = null, array $registers = array(), callable $tickFunction = null)
 	{
-		$context = new Context($assigns, $registers);
+		$context = new Context($assigns, $registers, $tickFunction);
 
 		if (!is_null($filters)) {
 			if (is_array($filters)) {

--- a/tests/Liquid/TickTest.php
+++ b/tests/Liquid/TickTest.php
@@ -13,21 +13,21 @@ namespace Liquid;
 
 class TickTest extends TestCase
 {
-    public function testSimpleVariable()
-    {
-        $ticks = 0;
+	public function testSimpleVariable()
+	{
+		$ticks = 0;
 
-        $template = new Template();
-        $template->parse("{% for i in (1..100) %}x{% endfor %}");
-        $this->assertEquals(str_pad('x', 100, 'x'), $template->render(
-            [],
-            [],
-            [],
-            function(Context $context) use (&$ticks) {
-                $ticks++;
-            }
-        ));
+		$template = new Template();
+		$template->parse("{% for i in (1..100) %}x{% endfor %}");
+		$this->assertEquals(str_pad('x', 100, 'x'), $template->render(
+			[],
+			[],
+			[],
+			function (Context $context) use (&$ticks) {
+				$ticks++;
+			}
+		));
 
-        $this->assertGreaterThanOrEqual(100, $ticks);
-    }
+		$this->assertGreaterThanOrEqual(100, $ticks);
+	}
 }

--- a/tests/Liquid/TickTest.php
+++ b/tests/Liquid/TickTest.php
@@ -29,20 +29,19 @@ class TickTest extends TestCase
 	 *
 	 * @param int $min
 	 * @param int $max
-	 * @param string $template
+	 * @param string $source
 	 */
-	public function testTicks($min, $max, $template)
+	public function testTicks($min, $max, $source)
 	{
 		$ticks = 0;
 
-		$context = new Context();
-		$context->setTickFunction(function (Context $context) use (&$ticks) {
+		$template = new Template();
+		$template->parse($source);
+		$template->setTickFunction(function (Context $context) use (&$ticks) {
 			$ticks++;
 		});
 
-		$tokens = Template::tokenize($template);
-		$document = new Document($tokens);
-		$document->render($context);
+		$template->render();
 
 		$this->assertGreaterThanOrEqual($min, $ticks);
 		$this->assertLessThanOrEqual($max, $ticks);

--- a/tests/Liquid/TickTest.php
+++ b/tests/Liquid/TickTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Liquid package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package Liquid
+ */
+
+namespace Liquid;
+
+class TickTest extends TestCase
+{
+    public function testSimpleVariable()
+    {
+        $ticks = 0;
+
+        $template = new Template();
+        $template->parse("{% for i in (1..100) %}x{% endfor %}");
+        $this->assertEquals(str_pad('x', 100, 'x'), $template->render(
+            [],
+            [],
+            [],
+            function(Context $context) use (&$ticks) {
+                $ticks++;
+            }
+        ));
+
+        $this->assertGreaterThanOrEqual(100, $ticks);
+    }
+}

--- a/tests/Liquid/TickTest.php
+++ b/tests/Liquid/TickTest.php
@@ -17,6 +17,7 @@ class TickTest extends TestCase
 	{
 		return [
 			[10, 11, '{% for i in (1..10) %}x{% endfor %}'],
+			[20, 40, '{% for i in (1..10) %}{% for ii in (1..2) %}x{% endfor %}{% endfor %}'],
 			[1, 2, '{% if true %} {% endif %}'],
 			[7, 8, '{% assign a = 0 %} {% increment a %} {% increment a %} {% increment a %}'],
 			[1, 1, ' ']


### PR DESCRIPTION
One problem we encountered is that an untrusted template could render for a very long time.
For example someone may could harm by running `for i in (1..[VERY_LARGE])` 

When ether liquid starts to render, there is no wqy to stop it. 
This PR introduces something similar like the [php tick function](http://php.net/manual/de/function.register-tick-function.php) for liquid. 

This PR would allow us track the rendering cost at runtime, abort it or do something else while the rendering started.

- [x] I've run the tests with `vendor/bin/phpunit`
- [x] None of the tests were found failing
- [x] I've seen the coverage report at `build/coverage/index.html`
- [x] Not a single line left uncovered by tests
- [x] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`


