### PR TITLE
Do not expose $_SERVER in templates by default

### DIFF
--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -62,8 +62,13 @@ class Context
 		$this->assigns = array($assigns);
 		$this->registers = $registers;
 		$this->filterbank = new Filterbank($this);
+
 		// first empty array serves as source for overrides, e.g. as in TagDecrement
-		$this->environments = array(array(), $_SERVER);
+		$this->environments = array(array(), array());
+
+		if (Liquid::get('EXPOSE_SERVER')) {
+			$this->environments[1] = $_SERVER;
+		}
 	}
 
 	/**

--- a/src/Liquid/Liquid.php
+++ b/src/Liquid/Liquid.php
@@ -77,7 +77,10 @@ class Liquid
 		'PAGINATION_REQUEST_KEY' => 'page',
 
 		// The name of the context key used to denote the current page number
-		'PAGINATION_CONTEXT_KEY' => 'page'
+		'PAGINATION_CONTEXT_KEY' => 'page',
+
+		// Whenever variables from $_SERVER should be directly available to templates
+		'EXPOSE_SERVER' => false,
 	);
 
 	/**

--- a/tests/Liquid/ContextTest.php
+++ b/tests/Liquid/ContextTest.php
@@ -392,4 +392,28 @@ class ContextTest extends TestCase
 		$context->set('test', 'test');
 		$this->assertEquals('test', $context->get('test'));
 	}
+
+	public function testServerNotExposedByDefault()
+	{
+		$_SERVER['AWS_SECRET_ACCESS_KEY'] = 'super_secret';
+
+		$context = new Context();
+		$this->assertNull($context->get('AWS_SECRET_ACCESS_KEY'));
+
+		$context->set('AWS_SECRET_ACCESS_KEY', 'test');
+		$this->assertEquals('test', $context->get('AWS_SECRET_ACCESS_KEY'));
+	}
+
+	public function testServerExposedWhenRequested()
+	{
+		Liquid::set('EXPOSE_SERVER', true);
+
+		$_SERVER['AWS_SECRET_ACCESS_KEY'] = 'super_secret';
+
+		$context = new Context();
+		$this->assertEquals('super_secret', $context->get('AWS_SECRET_ACCESS_KEY'));
+
+		$context->set('AWS_SECRET_ACCESS_KEY', 'test');
+		$this->assertEquals('super_secret', $context->get('AWS_SECRET_ACCESS_KEY'), '$_SERVER should take precedence in this case');
+	}
 }

--- a/tests/Liquid/TestCase.php
+++ b/tests/Liquid/TestCase.php
@@ -37,6 +37,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
 			'VARIABLE_START' => '{{',
 			'VARIABLE_END' => '}}',
 			'VARIABLE_NAME' => '[a-zA-Z_][a-zA-Z0-9_.-]*',
+			'EXPOSE_SERVER' => false,
 		);
 
 		foreach ($defaultConfig as $configKey => $configValue) {


### PR DESCRIPTION
This is important primarily because $_SERVER may contain sensitive
data, like AWS access keys, which then can be accessed from user-
provided templates.

Fixes #114

- [x] I've run the tests with `vendor/bin/phpunit`
- [x] None of the tests were found failing
- [x] I've seen the coverage report at `build/coverage/index.html`
- [x] Not a single line left uncovered by tests
- [x] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`
