### PR TITLE
Implement whitespace control for variables

### DIFF
--- a/src/Liquid/AbstractBlock.php
+++ b/src/Liquid/AbstractBlock.php
@@ -111,14 +111,14 @@ class AbstractBlock extends AbstractTag
 	 */
 	protected function whitespaceHandler(&$token)
 	{
-		if (mb_strlen($token) > 2 && mb_substr($token, 2, 1) === Liquid::get('WHITESPACE_CONTROL')) {
+		if (mb_substr($token, 2, 1) === Liquid::get('WHITESPACE_CONTROL')) {
 			$previousToken = end($this->nodelist);
 			if (is_string($previousToken)) {
 				$this->nodelist[key($this->nodelist)] = rtrim($previousToken);
 			}
 		}
 
-		self::$trimWhitespace = (mb_strlen($token) > 2 && mb_substr($token, -3, 1) === Liquid::get('WHITESPACE_CONTROL'));
+		self::$trimWhitespace = (mb_substr($token, -3, 1) === Liquid::get('WHITESPACE_CONTROL'));
 	}
 
 	/**

--- a/src/Liquid/AbstractBlock.php
+++ b/src/Liquid/AbstractBlock.php
@@ -50,7 +50,7 @@ class AbstractBlock extends AbstractTag
 	public function parse(array &$tokens)
 	{
 		$startRegexp = new Regexp('/^' . Liquid::get('TAG_START') . '/');
-		$tagRegexp = new Regexp('/^' . Liquid::get('TAG_START') . Liquid::get('WHITESPACE_CONTROL') . '?\s*(\w+)\s*(.*)?' . Liquid::get('WHITESPACE_CONTROL') . '?' . Liquid::get('TAG_END') . '$/');
+		$tagRegexp = new Regexp('/^' . Liquid::get('TAG_START') . Liquid::get('WHITESPACE_CONTROL') . '?\s*(\w+)\s*(.*?)' . Liquid::get('WHITESPACE_CONTROL') . '?' . Liquid::get('TAG_END') . '$/');
 		$variableStartRegexp = new Regexp('/^' . Liquid::get('VARIABLE_START') . '/');
 
 		$this->nodelist = array();
@@ -243,7 +243,7 @@ class AbstractBlock extends AbstractTag
 	 */
 	private function createVariable($token)
 	{
-		$variableRegexp = new Regexp('/^' . Liquid::get('VARIABLE_START') . Liquid::get('WHITESPACE_CONTROL') . '?(.*)' . Liquid::get('WHITESPACE_CONTROL') . '?' . Liquid::get('VARIABLE_END') . '$/');
+		$variableRegexp = new Regexp('/^' . Liquid::get('VARIABLE_START') . Liquid::get('WHITESPACE_CONTROL') . '?(.*?)' . Liquid::get('WHITESPACE_CONTROL') . '?' . Liquid::get('VARIABLE_END') . '$/');
 		if ($variableRegexp->match($token)) {
 			return new Variable($variableRegexp->matches[1]);
 		}

--- a/src/Liquid/AbstractBlock.php
+++ b/src/Liquid/AbstractBlock.php
@@ -111,14 +111,14 @@ class AbstractBlock extends AbstractTag
 	 */
 	protected function whitespaceHandler(&$token)
 	{
-		if (mb_strlen($token) > 2 && $token[2] === Liquid::get('WHITESPACE_CONTROL')) {
+		if (mb_strlen($token) > 2 && mb_substr($token, 2, 1) === Liquid::get('WHITESPACE_CONTROL')) {
 			$previousToken = end($this->nodelist);
 			if (is_string($previousToken)) {
 				$this->nodelist[key($this->nodelist)] = rtrim($previousToken);
 			}
 		}
 
-		self::$trimWhitespace = (mb_strlen($token) > 2 && substr($token, -3, 1) === Liquid::get('WHITESPACE_CONTROL'));
+		self::$trimWhitespace = (mb_strlen($token) > 2 && mb_substr($token, -3, 1) === Liquid::get('WHITESPACE_CONTROL'));
 	}
 
 	/**

--- a/src/Liquid/AbstractBlock.php
+++ b/src/Liquid/AbstractBlock.php
@@ -118,7 +118,7 @@ class AbstractBlock extends AbstractTag
 			}
 		}
 
-		self::$trimWhitespace = (mb_strlen($token) > 2 && $token[-3] === Liquid::get('WHITESPACE_CONTROL'));
+		self::$trimWhitespace = (mb_strlen($token) > 2 && substr($token, -3, 1) === Liquid::get('WHITESPACE_CONTROL'));
 	}
 
 	/**

--- a/src/Liquid/AbstractBlock.php
+++ b/src/Liquid/AbstractBlock.php
@@ -27,6 +27,11 @@ class AbstractBlock extends AbstractTag
 	protected $nodelist = array();
 
 	/**
+	 * @var bool
+	 */
+	protected static $trimWhitespace = false;
+
+	/**
 	 * @return array
 	 */
 	public function getNodelist()
@@ -45,7 +50,7 @@ class AbstractBlock extends AbstractTag
 	public function parse(array &$tokens)
 	{
 		$startRegexp = new Regexp('/^' . Liquid::get('TAG_START') . '/');
-		$tagRegexp = new Regexp('/^' . Liquid::get('TAG_START') . '\s*(\w+)\s*(.*)?' . Liquid::get('TAG_END') . '$/');
+		$tagRegexp = new Regexp('/^' . Liquid::get('TAG_START') . Liquid::get('WHITESPACE_CONTROL') . '?\s*(\w+)\s*(.*)?' . Liquid::get('WHITESPACE_CONTROL') . '?' . Liquid::get('TAG_END') . '$/');
 		$variableStartRegexp = new Regexp('/^' . Liquid::get('VARIABLE_START') . '/');
 
 		$this->nodelist = array();
@@ -56,6 +61,7 @@ class AbstractBlock extends AbstractTag
 			$token = array_shift($tokens);
 
 			if ($startRegexp->match($token)) {
+				$this->whitespaceHandler($token);
 				if ($tagRegexp->match($token)) {
 					// If we found the proper block delimitor just end parsing here and let the outer block proceed
 					if ($tagRegexp->matches[1] == $this->blockDelimiter()) {
@@ -83,13 +89,36 @@ class AbstractBlock extends AbstractTag
 					throw new ParseException("Tag $token was not properly terminated (won't match $tagRegexp)");
 				}
 			} elseif ($variableStartRegexp->match($token)) {
+				$this->whitespaceHandler($token);
 				$this->nodelist[] = $this->createVariable($token);
-			} elseif ($token != '') {
+			} else {
+				if (self::$trimWhitespace) {
+					$token = ltrim($token);
+				}
+
+				self::$trimWhitespace = false;
 				$this->nodelist[] = $token;
 			}
 		}
 
 		$this->assertMissingDelimitation();
+	}
+
+	/**
+	 * Handle the whitespace.
+	 *
+	 * @param string $token
+	 */
+	protected function whitespaceHandler(&$token)
+	{
+		if (mb_strlen($token) > 2 && $token[2] === Liquid::get('WHITESPACE_CONTROL')) {
+			$previousToken = end($this->nodelist);
+			if (is_string($previousToken)) {
+				$this->nodelist[key($this->nodelist)] = rtrim($previousToken);
+			}
+		}
+
+		self::$trimWhitespace = (mb_strlen($token) > 2 && $token[-3] === Liquid::get('WHITESPACE_CONTROL'));
 	}
 
 	/**
@@ -214,7 +243,7 @@ class AbstractBlock extends AbstractTag
 	 */
 	private function createVariable($token)
 	{
-		$variableRegexp = new Regexp('/^' . Liquid::get('VARIABLE_START') . '(.*)' . Liquid::get('VARIABLE_END') . '$/');
+		$variableRegexp = new Regexp('/^' . Liquid::get('VARIABLE_START') . Liquid::get('WHITESPACE_CONTROL') . '?(.*)' . Liquid::get('WHITESPACE_CONTROL') . '?' . Liquid::get('VARIABLE_END') . '$/');
 		if ($variableRegexp->match($token)) {
 			return new Variable($variableRegexp->matches[1]);
 		}

--- a/src/Liquid/Liquid.php
+++ b/src/Liquid/Liquid.php
@@ -52,11 +52,14 @@ class Liquid
 		// Prefix for include files.
 		'INCLUDE_PREFIX' => '_',
 
+		// Whitespace control.
+		'WHITESPACE_CONTROL' => '-',
+
 		// Tag start.
-		'TAG_START' => '(?:{%|\s*{%-)',
+		'TAG_START' => '{%',
 
 		// Tag end.
-		'TAG_END' => '(?:%}|-%}\s*)',
+		'TAG_END' => '%}',
 
 		// Variable start.
 		'VARIABLE_START' => '{{',

--- a/tests/Liquid/Tag/TagIfTest.php
+++ b/tests/Liquid/Tag/TagIfTest.php
@@ -158,6 +158,12 @@ class TagIfTest extends TestCase
 		$this->assertTemplateResult($expected, $text, array('var' => 1));
 	}
 
+	public function testNotNilWhitespaceControlEdgeCase()
+	{
+		$this->assertTemplateResult("true", "{% if 1 -%}true{% endif %}");
+		$this->assertTemplateResult("true", "{% if 1 -%} true{% endif %}");
+	}
+
 	public function testIfFromVariable()
 	{
 		$this->assertTemplateResult('', '{% if var %} NO {% endif %}', array('var' => false));

--- a/tests/Liquid/fixtures/whitespace-control.html
+++ b/tests/Liquid/fixtures/whitespace-control.html
@@ -1,6 +1,7 @@
 --
 
 
-  Wow, John G. Chalmers-Smith, you have a long name!
+  Wow,
+  	John G. Chalmers-Smith, you have a long name!
 
---Wow, John G. Chalmers-Smith, you have a long name!--
+--Wow,John G. Chalmers-Smith, you have a long name!--

--- a/tests/Liquid/fixtures/whitespace-control.liquid
+++ b/tests/Liquid/fixtures/whitespace-control.liquid
@@ -1,14 +1,16 @@
 --
 {% assign username = "John G. Chalmers-Smith" %}
 {% if username and username.size > 10 %}
-  Wow, {{ username }}, you have a long name!
+  Wow,
+  	{{ username }}, you have a long name!
 {% else %}
   Hello there!
 {% endif %}
 --
 {%- assign username = "John G. Chalmers-Smith" -%}
 {%- if username and username.size > 10 -%}
-  Wow, {{ username }}, you have a long name!
+  Wow,
+  	{{- username -}}, you have a long name!
 {%- else -%}
   Hello there!
 {%- endif -%}


### PR DESCRIPTION
- [x] I've run the tests with `vendor/bin/phpunit`
- [x] None of the tests were found failing
- [x] I've seen the coverage report at `build/coverage/index.html`
- [x] Not a single line left uncovered by tests
- [x] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`

Builds on whitespace control introduced in #110 and discussed in #109 using implementation based on the ruby version of Liquid. Adds support for whitespace control of variables.