### PR TITLE
Fix for whitespace ctrl/if tag edge case

### DIFF
--- a/src/Liquid/AbstractBlock.php
+++ b/src/Liquid/AbstractBlock.php
@@ -45,7 +45,7 @@ class AbstractBlock extends AbstractTag
 	public function parse(array &$tokens)
 	{
 		$startRegexp = new Regexp('/^' . Liquid::get('TAG_START') . '/');
-		$tagRegexp = new Regexp('/^' . Liquid::get('TAG_START') . '\s*(\w+)\s*(.*)?' . Liquid::get('TAG_END') . '$/');
+		$tagRegexp = new Regexp('/^' . Liquid::get('TAG_START') . '\s*(\w+)\s*(.*?)' . Liquid::get('TAG_END') . '$/');
 		$variableStartRegexp = new Regexp('/^' . Liquid::get('VARIABLE_START') . '/');
 
 		$this->nodelist = array();

--- a/tests/Liquid/Tag/TagIfTest.php
+++ b/tests/Liquid/Tag/TagIfTest.php
@@ -158,6 +158,12 @@ class TagIfTest extends TestCase
 		$this->assertTemplateResult($expected, $text, array('var' => 1));
 	}
 
+	public function testNotNilWhitespaceControlEdgeCase()
+	{
+		$this->assertTemplateResult("true", "{% if 1 -%}true{% endif %}");
+		$this->assertTemplateResult("true", "{% if 1 -%} true{% endif %}");
+	}
+
 	public function testIfFromVariable()
 	{
 		$this->assertTemplateResult('', '{% if var %} NO {% endif %}', array('var' => false));


### PR DESCRIPTION
The following `{%- if 1 -%}display{% endif %}` should output `display`. However due to the greediness of the regex the `-` at the end of the tag gets globed up and the `-` is now considered the operator for the if condition. Resulting in it always evaluating to `false` since the right hand operand is `null`.

`\s*(\w+)\s*(.*)?` --> `\s*(\w+)\s*(.*?)`

Looks to me like this was probably just an inadvertent typo from when the initial port was done.

- [x] I've run the tests with `vendor/bin/phpunit`
- [x] None of the tests were found failing
- [x] I've seen the coverage report at `build/coverage/index.html`
- [x] Not a single line left uncovered by tests
- [x] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`
