### PR TITLE
Add wrapper for call_user_func_array() with try/catch block.

### DIFF
--- a/src/Liquid/Filterbank.php
+++ b/src/Liquid/Filterbank.php
@@ -134,7 +134,7 @@ class Filterbank
 
 		// If we have a callback
 		if (is_callable($class)) {
-			return call_user_func_array($class, $args);
+			return $this->callUserFuncArrayInTryCatch($class, $args);
 		}
 
 		// If we have a registered object for the class, use that instead
@@ -144,10 +144,29 @@ class Filterbank
 
 		// If we're calling a function
 		if ($class === false) {
-			return call_user_func_array($name, $args);
+			return $this->callUserFuncArrayInTryCatch($name, $args);
 		}
 
 		// Call a class or an instance method
-		return call_user_func_array(array($class, $name), $args);
+		return $this->callUserFuncArrayInTryCatch(array($class, $name), $args);
+	}
+
+	/**
+	 * This is a wrapper for call_user_func_array() with try/catch
+	 * to cast TypeError in LiquidException.
+	 *
+	 * @param callback $function
+	 * @param array $param_arr
+	 *
+	 * @throws \Liquid\LiquidException
+	 * @return mixed
+	 */
+	private function callUserFuncArrayInTryCatch($function, array $param_arr)
+	{
+		try {
+			return call_user_func_array($function, $param_arr);
+		} catch (\TypeError $typeError) {
+			throw new LiquidException($typeError->getMessage(), 0, $typeError);
+		}
 	}
 }

--- a/tests/Liquid/FilterbankTest.php
+++ b/tests/Liquid/FilterbankTest.php
@@ -104,6 +104,17 @@ class FilterbankTest extends TestCase
 		$this->filterBank->addFilter('no_such_function_or_class');
 	}
 
+
+	/**
+	 * @expectedException \Liquid\LiquidException
+	 */
+	public function testTypeErrorExceptionAndCallDateFilterWithoutArguments()
+	{
+		$var = new Variable('var | date');
+		$this->context->set('var', 1000);
+		$this->assertEquals('worked', $var->render($this->context));
+	}
+
 	public function testInvokeNoFilter()
 	{
 		$value = 'value';


### PR DESCRIPTION
Catch TypeError and rethrow LiquidException because Filter is called
with too few arguments.
A LiquidException is more meaningful as TypeError and developer can
handle this like liquid template error.

Fixes #126

- [x] I've run the tests with `vendor/bin/phpunit`
- [x] None of the tests were found failing
- [x] I've seen the coverage report at `build/coverage/index.html`
- [x] Not a single line left uncovered by tests
- [x] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`
