### PR TITLE
Add support for array first/last dot notation

### DIFF
--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -331,12 +331,12 @@ class Context
 
 			if (is_array($object)) {
 				// if the last part of the context variable is .first we return the first array element
-				if ($nextPartName == 'first' && count($parts) == 0 && !Liquid::arrayIsAssoc($object)) {
+				if ($nextPartName == 'first' && count($parts) == 0 && !array_key_exists('first', $object)) {
 					return StandardFilters::first($object);
 				}
 
 				// if the last part of the context variable is .last we return the last array element
-				if ($nextPartName == 'last' && count($parts) == 0 && !Liquid::arrayIsAssoc($object)) {
+				if ($nextPartName == 'last' && count($parts) == 0 && !array_key_exists('last', $object)) {
 					return StandardFilters::last($object);
 				}
 

--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -330,6 +330,16 @@ class Context
 			}
 
 			if (is_array($object)) {
+				// if the last part of the context variable is .first we return the first array element
+				if ($nextPartName == 'first' && count($parts) == 0 && !Liquid::arrayIsAssoc($object)) {
+					return StandardFilters::first($object);
+				}
+
+				// if the last part of the context variable is .first we return the last array element
+				if ($nextPartName == 'last' && count($parts) == 0 && !Liquid::arrayIsAssoc($object)) {
+					return StandardFilters::last($object);
+				}
+
 				// if the last part of the context variable is .size we just return the count
 				if ($nextPartName == 'size' && count($parts) == 0 && !array_key_exists('size', $object)) {
 					return count($object);

--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -335,7 +335,7 @@ class Context
 					return StandardFilters::first($object);
 				}
 
-				// if the last part of the context variable is .first we return the last array element
+				// if the last part of the context variable is .last we return the last array element
 				if ($nextPartName == 'last' && count($parts) == 0 && !Liquid::arrayIsAssoc($object)) {
 					return StandardFilters::last($object);
 				}

--- a/src/Liquid/Liquid.php
+++ b/src/Liquid/Liquid.php
@@ -151,4 +151,18 @@ class Liquid
 		}
 		return $return;
 	}
+
+	/**
+	 * Check if an array is associative or not.
+	 *
+	 * @param array $array
+	 *
+	 * @return bool
+	 */
+	public static function arrayIsAssoc($array)
+	{
+		$keys = array_keys($array);
+
+		return array_keys($keys) !== $keys;
+	}
 }

--- a/src/Liquid/Liquid.php
+++ b/src/Liquid/Liquid.php
@@ -159,7 +159,7 @@ class Liquid
 	 *
 	 * @return bool
 	 */
-	public static function arrayIsAssoc($array)
+	public static function arrayIsAssoc(array $array)
 	{
 		$keys = array_keys($array);
 

--- a/src/Liquid/Liquid.php
+++ b/src/Liquid/Liquid.php
@@ -151,18 +151,4 @@ class Liquid
 		}
 		return $return;
 	}
-
-	/**
-	 * Check if an array is associative or not.
-	 *
-	 * @param array $array
-	 *
-	 * @return bool
-	 */
-	public static function arrayIsAssoc(array $array)
-	{
-		$keys = array_keys($array);
-
-		return array_keys($keys) !== $keys;
-	}
 }

--- a/tests/Liquid/ContextTest.php
+++ b/tests/Liquid/ContextTest.php
@@ -319,6 +319,18 @@ class ContextTest extends TestCase
 		$this->assertEquals(5000, $this->context->get('hash.size'));
 	}
 
+	public function testArrayFirst()
+	{
+		$this->context->set('array', array(11, 'jack', 43, 74, 5, 'tom'));
+		$this->assertEquals(11, $this->context->get('array.first'));
+	}
+
+	public function testArrayLast()
+	{
+		$this->context->set('array', array(11, 'jack', 43, 74, 5, 'tom'));
+		$this->assertEquals('tom', $this->context->get('array.last'));
+	}
+
 	public function testDeepValueNotObject()
 	{
 		$this->context->set('example', array('foo' => new ToLiquidNotObject()));

--- a/tests/Liquid/ContextTest.php
+++ b/tests/Liquid/ContextTest.php
@@ -325,10 +325,22 @@ class ContextTest extends TestCase
 		$this->assertEquals(11, $this->context->get('array.first'));
 	}
 
+	public function testOverrideFirst()
+	{
+		$this->context->set('array', array(11, 'jack', 43, 'first' => 74, 5, 'tom'));
+		$this->assertEquals(74, $this->context->get('array.first'));
+	}
+
 	public function testArrayLast()
 	{
 		$this->context->set('array', array(11, 'jack', 43, 74, 5, 'tom'));
 		$this->assertEquals('tom', $this->context->get('array.last'));
+	}
+
+	public function testOverrideLast()
+	{
+		$this->context->set('array', array(11, 'jack', 43, 'last' => 74, 5, 'tom'));
+		$this->assertEquals(74, $this->context->get('array.last'));
 	}
 
 	public function testDeepValueNotObject()


### PR DESCRIPTION
- [x] I've run the tests with `vendor/bin/phpunit`
- [x] None of the tests were found failing
- [x] I've seen the coverage report at `build/coverage/index.html`
- [x] Not a single line left uncovered by tests
- [x] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`

> Array first and last. If you have an expression whose value is an array, you can follow it with .first or .last to resolve to its first or last element.
https://github.com/Shopify/liquid/wiki/Liquid-for-Designers
