### PR TITLE
Fix bug preventing keyword args from being used with filters

### DIFF
--- a/src/Liquid/Liquid.php
+++ b/src/Liquid/Liquid.php
@@ -70,7 +70,7 @@ class Liquid
 		// Variable name.
 		'VARIABLE_NAME' => '[a-zA-Z_][a-zA-Z_0-9.-]*',
 
-		'QUOTED_STRING' => '"[^"]*"|\'[^\']*\'',
+		'QUOTED_STRING' => '(?:"[^"]*"|\'[^\']*\')',
 		'QUOTED_STRING_FILTER_ARGUMENT' => '"[^"]*"|\'[^\']*\'',
 
 		// Automatically escape any variables unless told otherwise by a "raw" filter
@@ -105,7 +105,7 @@ class Liquid
 		// This case is needed for compound settings
 		switch ($key) {
 				case 'QUOTED_FRAGMENT':
-					return self::$config['QUOTED_STRING'] . '|(?:[^\s,\|\'"]|' . self::$config['QUOTED_STRING'] . ')+';
+					return '(?:' . self::get('QUOTED_STRING') . '|(?:[^\s,\|\'"]|' . self::get('QUOTED_STRING') . ')+)';
 				case 'TAG_ATTRIBUTES':
 					return '/(\w+)\s*\:\s*(' . self::get('QUOTED_FRAGMENT') . ')/';
 				case 'TOKENIZATION_REGEXP':

--- a/src/Liquid/Variable.php
+++ b/src/Liquid/Variable.php
@@ -60,7 +60,7 @@ class Variable
 						$filterName = $matches[0];
 						$filterArgsRegex->matchAll($filter);
 						$matches = Liquid::arrayFlatten($filterArgsRegex->matches[1]);
-						$this->filters[] = array($filterName, $matches);
+						$this->filters[] = $this->parseFilterExpressions($filterName, $matches);
 					}
 				}
 			}
@@ -91,6 +91,32 @@ class Variable
 		}
 	}
 
+	/**
+	 * @param string $filterName
+	 * @param array $unparsedArgs
+	 * @return array
+	 */
+	private function parseFilterExpressions($filterName, array $unparsedArgs)
+	{
+		$filterArgs = array();
+		$keywordArgs = array();
+
+		$justTagAttributes = new Regexp('/\A' . trim(Liquid::get('TAG_ATTRIBUTES'), '/') . '\z/');
+
+		foreach ($unparsedArgs as $a) {
+			if ($justTagAttributes->match($a)) {
+				$keywordArgs[$justTagAttributes->matches[1]] = $justTagAttributes->matches[2];
+			} else {
+				$filterArgs[] = $a;
+			}
+		}
+
+		if (count($keywordArgs)) {
+			$filterArgs[] = $keywordArgs;
+		}
+
+		return array($filterName, $filterArgs);
+	}
 
 	/**
 	 * Gets the variable name
@@ -126,9 +152,18 @@ class Variable
 			list($filtername, $filterArgKeys) = $filter;
 
 			$filterArgValues = array();
+			$keywordArgValues = array();
 
 			foreach ($filterArgKeys as $arg_key) {
-				$filterArgValues[] = $context->get($arg_key);
+				if (is_array($arg_key)) {
+					foreach ($arg_key as $keywordArgName => $keywordArgKey) {
+						$keywordArgValues[$keywordArgName] = $context->get($keywordArgKey);
+					}
+
+					$filterArgValues[] = $keywordArgValues;
+				} else {
+					$filterArgValues[] = $context->get($arg_key);
+				}
 			}
 
 			$output = $context->invoke($filtername, $output, $filterArgValues);

--- a/src/Liquid/Variable.php
+++ b/src/Liquid/Variable.php
@@ -96,7 +96,7 @@ class Variable
 	 * @param array $unparsedArgs
 	 * @return array
 	 */
-	private function parseFilterExpressions($filterName, array $unparsedArgs)
+	private static function parseFilterExpressions($filterName, array $unparsedArgs)
 	{
 		$filterArgs = array();
 		$keywordArgs = array();

--- a/tests/Liquid/OutputTest.php
+++ b/tests/Liquid/OutputTest.php
@@ -42,6 +42,26 @@ class FunnyFilter
 	{
 		return "<a href=\"" . $protocol . '://' .$url . "\">" . $name . "</a>";
 	}
+
+	public function str_replace($input, $data)
+	{
+		foreach ($data as $k => $v) {
+			$input = str_replace("[" . $k . "]", $v, $input);
+		}
+		return $input;
+	}
+
+	public function img_url($input, $size, $opts = null)
+	{
+		$output = "image_" . $size;
+		if (isset($opts['crop'])) {
+			$output .= "_cropped_" . $opts['crop'];
+		}
+		if (isset($opts['scale'])) {
+			$output .= "@" . $opts['scale'] . 'x';
+		}
+		return $output . ".png";
+	}
 }
 
 class OutputTest extends TestCase
@@ -128,6 +148,22 @@ class OutputTest extends TestCase
 	{
 		$text = " {{ car.gm | add_tag : 'span', car.bmw}} ";
 		$expected = " <span id=\"good\">bad</span> ";
+
+		$this->assertTemplateResult($expected, $text, $this->assigns);
+	}
+
+	public function testVariablePipingWithKeywordArg()
+	{
+		$text = " {{ 'Welcome, [name]' | str_replace: name: 'Santa' }} ";
+		$expected = " Welcome, Santa ";
+
+		$this->assertTemplateResult($expected, $text, $this->assigns);
+	}
+
+	public function testVariablePipingWithArgsAndKeywordArgs()
+	{
+		$text = " {{ car.gm | img_url: '450x450', crop: 'center', scale: 2 }} ";
+		$expected = " image_450x450_cropped_center@2x.png ";
 
 		$this->assertTemplateResult($expected, $text, $this->assigns);
 	}

--- a/tests/Liquid/VariableTest.php
+++ b/tests/Liquid/VariableTest.php
@@ -60,6 +60,10 @@ class VariableTest extends TestCase
 		$var = new Variable(" hello | things: \"%Y, okay?\", 'the other one'");
 		$this->assertEquals('hello', $var->getName());
 		$this->assertEquals(array(array('things', array('"%Y, okay?"', "'the other one'"))), $var->getFilters());
+
+		$var = new Variable(" product.featured_image | img_url: '450x450', crop: 'center', scale: 2 ");
+		$this->assertEquals("product.featured_image", $var->getName());
+		$this->assertEquals(array(array('img_url', array("'450x450'", array("crop" => "'center'", "scale" => "2")))), $var->getFilters());
 	}
 
 	public function testFiltersWithoutWhitespace()


### PR DESCRIPTION
- [x] I've run the tests with `vendor/bin/phpunit`
- [x] None of the tests were found failing
- [x] I've seen the coverage report at `build/coverage/index.html`
- [x] Not a single line left uncovered by tests
- [x] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`

## Summary
**1) Fixing the regex bug**

When Ruby performs the regexp interpolation the regex being inserted is essentially wrapped in a non-capture group.

![ regexp-interpolation](https://user-images.githubusercontent.com/9314/76928698-b2b99780-68b8-11ea-9220-3fb3cafc02da.png)

However if you concatenate all the parts (like we were doing with them) instead of interpolating them if the regex being inserted has an OR then you basically end up with an entirely different regex.

![regexp-concatenation](https://user-images.githubusercontent.com/9314/76928470-f95ac200-68b7-11ea-8307-0adc3b370216.png)

**2) Updating the parsing of the filter args to properly account for keyword args**

For example, the following filter should be possible.
```liquid
<img src="{{ product.featured_image | img_url: '450x450’, crop: 'center' }}">
```

