### PR TITLE
Autoload warnings with liquid strings

### DIFF
--- a/src/Liquid/Context.php
+++ b/src/Liquid/Context.php
@@ -416,7 +416,7 @@ class Context
 		// lastly, try to get an embedded value of an object
 		// value could be of any type, not just string, so we have to do this
 		// conversion here, not later in AbstractBlock::renderAll
-		if (method_exists($object, 'toLiquid')) {
+		if (is_object($object) && method_exists($object, 'toLiquid')) {
 			$object = $object->toLiquid();
 		}
 


### PR DESCRIPTION
If the $object variable is a string php will attempt to load a class with the value of $object and check that class for the method toLiquid.

When using older auto loading code this generates warnings attempting to load classes for every liquid string.

