### PR TITLE
If the $token variable is a string php will attempt to load a class

### DIFF
--- a/src/Liquid/AbstractBlock.php
+++ b/src/Liquid/AbstractBlock.php
@@ -157,7 +157,7 @@ class AbstractBlock extends AbstractTag
 		$result = '';
 
 		foreach ($list as $token) {
-			if (method_exists($token, 'render')) {
+			if (is_object($token) && method_exists($token, 'render')) {
 				$value = $token->render($context);
 			} else {
 				$value = $token;


### PR DESCRIPTION
If the $token variable is a string php will attempt to load a class with the value of $token and check for the Render method

When using older auto loading code this generates warnings attempting to load classes for a liquid string
