### PR TITLE
Allow arrays to be output to template as string, rather than throwing an exception.

### DIFF
--- a/src/Liquid/AbstractBlock.php
+++ b/src/Liquid/AbstractBlock.php
@@ -164,7 +164,7 @@ class AbstractBlock extends AbstractTag
 			}
 
 			if (is_array($value)) {
-				$value = print_r($value, true);
+				$value = htmlspecialchars(print_r($value, true));
 			}
 
 			$result .= $value;

--- a/src/Liquid/AbstractBlock.php
+++ b/src/Liquid/AbstractBlock.php
@@ -164,7 +164,7 @@ class AbstractBlock extends AbstractTag
 			}
 
 			if (is_array($value)) {
-				throw new RenderException("Implicit rendering of arrays not supported. Use index operator.");
+				$value = print_r($value, true);
 			}
 
 			$result .= $value;

--- a/tests/Liquid/Tag/TagIncludeTest.php
+++ b/tests/Liquid/Tag/TagIncludeTest.php
@@ -160,7 +160,7 @@ class TagIncludeTest extends TestCase
 		$template->parse("{% include 'example' %}");
 		
 		$output = $template->render(array("var" => array("a", "b", "c")));
-		$expectedOutput = print_r(array("a", "b", "c"),true);
+		$expectedOutput = print_r(array("a", "b", "c"), true);
 		$this->assertEquals("([$expectedOutput])", $output);
 	}
 

--- a/tests/Liquid/Tag/TagIncludeTest.php
+++ b/tests/Liquid/Tag/TagIncludeTest.php
@@ -151,9 +151,6 @@ class TagIncludeTest extends TestCase
 	 */
 	public function testIncludePassArrayWithoutIndex()
 	{
-		$this->expectException(\Liquid\Exception\RenderException::class);
-		$this->expectExceptionMessage('Use index operator');
-
 		$template = new Template();
 		$template->setFileSystem(TestFileSystem::fromArray(array(
 			'inner' => "[{{ other }}]",
@@ -161,7 +158,9 @@ class TagIncludeTest extends TestCase
 		)));
 
 		$template->parse("{% include 'example' %}");
-		$template->render(array("var" => array("a", "b", "c")));
+		
+		$output = $template->render(array("var" => array("a", "b", "c")));
+		$this->assertEquals("([a])", $output);
 	}
 
 	public function testIncludePassArrayWithIndex()
@@ -175,7 +174,13 @@ class TagIncludeTest extends TestCase
 		$template->parse("{% include 'example' %}");
 
 		$output = $template->render(array("var" => array("a", "b", "c")));
-		$this->assertEquals("([a])", $output);
+		$expectedOutput = "Array
+(
+    [0] => a
+    [1] => b
+    [2] => c
+)";
+		$this->assertEquals($expectedOutput, $output);
 	}
 
 	public function testIncludePassObjectValue()

--- a/tests/Liquid/Tag/TagIncludeTest.php
+++ b/tests/Liquid/Tag/TagIncludeTest.php
@@ -160,7 +160,7 @@ class TagIncludeTest extends TestCase
 		$template->parse("{% include 'example' %}");
 		
 		$output = $template->render(array("var" => array("a", "b", "c")));
-		$expectedOutput = print_r(array("a", "b", "c"), true);
+		$expectedOutput = htmlspecialchars(print_r(array("a", "b", "c"), true));
 		$this->assertEquals("([$expectedOutput])", $output);
 	}
 

--- a/tests/Liquid/Tag/TagIncludeTest.php
+++ b/tests/Liquid/Tag/TagIncludeTest.php
@@ -160,7 +160,8 @@ class TagIncludeTest extends TestCase
 		$template->parse("{% include 'example' %}");
 		
 		$output = $template->render(array("var" => array("a", "b", "c")));
-		$this->assertEquals("([a])", $output);
+		$expectedOutput = print_r(array("a", "b", "c"),true);
+		$this->assertEquals("([$expectedOutput])", $output);
 	}
 
 	public function testIncludePassArrayWithIndex()
@@ -174,13 +175,7 @@ class TagIncludeTest extends TestCase
 		$template->parse("{% include 'example' %}");
 
 		$output = $template->render(array("var" => array("a", "b", "c")));
-		$expectedOutput = "Array
-(
-    [0] => a
-    [1] => b
-    [2] => c
-)";
-		$this->assertEquals($expectedOutput, $output);
+		$this->assertEquals("([a])", $output);
 	}
 
 	public function testIncludePassObjectValue()


### PR DESCRIPTION
- [x] I've run the tests with `vendor/bin/phpunit`
- [x] None of the tests were found failing
- [x] I've seen the coverage report at `build/coverage/index.html`
- [x] Not a single line left uncovered by tests
- [x] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`

Rather than throwing an exception, simply convert the array to a string, as per the original Shopify implementation.