### PR TITLE
fix parse exception "tag was never closed" with line break

### DIFF
--- a/src/Liquid/AbstractBlock.php
+++ b/src/Liquid/AbstractBlock.php
@@ -52,7 +52,7 @@ class AbstractBlock extends AbstractTag
 	public function parse(array &$tokens)
 	{
 		$startRegexp = new Regexp('/^' . Liquid::get('TAG_START') . '/');
-		$tagRegexp = new Regexp('/^' . Liquid::get('TAG_START') . Liquid::get('WHITESPACE_CONTROL') . '?\s*(\w+)\s*(.*?)' . Liquid::get('WHITESPACE_CONTROL') . '?' . Liquid::get('TAG_END') . '$/');
+		$tagRegexp = new Regexp('/^' . Liquid::get('TAG_START') . Liquid::get('WHITESPACE_CONTROL') . '?\s*(\w+)\s*(.*?)' . Liquid::get('WHITESPACE_CONTROL') . '?' . Liquid::get('TAG_END') . '$/s');
 		$variableStartRegexp = new Regexp('/^' . Liquid::get('VARIABLE_START') . '/');
 
 		$this->nodelist = array();

--- a/tests/Liquid/Tag/TagIfTest.php
+++ b/tests/Liquid/Tag/TagIfTest.php
@@ -231,6 +231,13 @@ class TagIfTest extends TestCase
 
 		$this->assertTemplateResult('', '{% if jerry == 1 %}');
 	}
+	public function testSyntaxErrorNotClosedLineBreak()
+	{
+		$this->expectException(\Liquid\Exception\ParseException::class);
+		$this->expectExceptionMessage('if tag was never closed');
+
+		$this->assertTemplateResult('', "{% if jerry\n == 1 %}");
+	}
 
 	/**
 	 */

--- a/tests/Liquid/Tag/TagIfTest.php
+++ b/tests/Liquid/Tag/TagIfTest.php
@@ -231,6 +231,7 @@ class TagIfTest extends TestCase
 
 		$this->assertTemplateResult('', '{% if jerry == 1 %}');
 	}
+
 	public function testSyntaxErrorNotClosedLineBreak()
 	{
 		$this->expectException(\Liquid\Exception\ParseException::class);


### PR DESCRIPTION
Fix not correct parse start tag with line break:
```
{% if jerry
 == 1 %}{% endif %}
```
For this template I see error: `if tag was never closed`