### PR TITLE
Fix PHP 8.1 error in preg_split by replacing null with default value

### DIFF
--- a/src/Liquid/Template.php
+++ b/src/Liquid/Template.php
@@ -172,7 +172,7 @@ class Template
 	{
 		return empty($source)
 			? array()
-			: preg_split(Liquid::get('TOKENIZATION_REGEXP'), $source, null, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+			: preg_split(Liquid::get('TOKENIZATION_REGEXP'), $source, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
 	}
 
 	/**


### PR DESCRIPTION
This fixes the following deprecation warning: Deprecated Functionality: preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated in vendor/liquid/liquid/src/Liquid/Template.php on line 175

- [x] I've run the tests with `vendor/bin/phpunit`
- [x] None of the tests were found failing
- [ ] I've seen the coverage report at `build/coverage/index.html`
- [ ] Not a single line left uncovered by tests
- [x] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`

```
 ~/development/workspace/php-liquid   master ±  vendor/bin/phpunit
PHPUnit 9.5.20 #StandWithUkraine

Runtime:       PHP 7.4.28
Configuration: /data/php-liquid/phpunit.xml.dist
Random Seed:   1650005968
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

...............................................................  63 / 367 ( 17%)
..................................I..I.......S.......I......... 126 / 367 ( 34%)
............................................................... 189 / 367 ( 51%)
............................................................... 252 / 367 ( 68%)
............................................................... 315 / 367 ( 85%)
.................................................SSS            367 / 367 (100%)

Time: 00:01.385, Memory: 18.00 MB

There were 3 incomplete tests:

1) Liquid\Tag\TagIncludeTest::testInvalidSyntaxInvalidKeyword
Exception is expected here

/data/php-liquid/tests/Liquid/Tag/TagIncludeTest.php:71
phpvfscomposer:///data/php-liquid/vendor/phpunit/phpunit/phpunit:97

2) Liquid\Tag\TagIncludeTest::testInvalidSyntaxNoObjectCollection
Exception is expected here

/data/php-liquid/tests/Liquid/Tag/TagIncludeTest.php:80
phpvfscomposer:///data/php-liquid/vendor/phpunit/phpunit/phpunit:97

3) Liquid\Tag\TagExtendsTest::testInvalidSyntaxInvalidKeyword
Exception is expected here

/data/php-liquid/tests/Liquid/Tag/TagExtendsTest.php:213
phpvfscomposer:///data/php-liquid/vendor/phpunit/phpunit/phpunit:97

--

There were 4 skipped tests:

1) Liquid\Tag\TagIncludeTest::testWithCache
This test depends on "Liquid\Tag\TagIncludeTest::testInvalidSyntaxNoObjectCollection" to pass.

phpvfscomposer:///data/php-liquid/vendor/phpunit/phpunit/phpunit:97

2) Liquid\Cache\ApcTest::testSetGetFlush
Alternative PHP Cache (APC) not available

/data/php-liquid/tests/Liquid/Cache/ApcTest.php:26
phpvfscomposer:///data/php-liquid/vendor/phpunit/phpunit/phpunit:97

3) Liquid\Cache\ApcTest::testNotExists
Alternative PHP Cache (APC) not available

/data/php-liquid/tests/Liquid/Cache/ApcTest.php:26
phpvfscomposer:///data/php-liquid/vendor/phpunit/phpunit/phpunit:97

4) Liquid\Cache\ApcTest::testReadNotExisting
Alternative PHP Cache (APC) not available

/data/php-liquid/tests/Liquid/Cache/ApcTest.php:26
phpvfscomposer:///data/php-liquid/vendor/phpunit/phpunit/phpunit:97

OK, but incomplete, skipped, or risky tests!
Tests: 367, Assertions: 789, Skipped: 4, Incomplete: 3.

```