### PR TITLE
Align split filter behaviour with Shopify/Ruby Liquid

### DIFF
--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -567,6 +567,10 @@ class StandardFilters
 	 */
 	public static function split($input, $pattern)
 	{
+		if ($input === '' || $input === null) {
+			return [];
+		}
+
 		return explode($pattern, $input);
 	}
 

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -792,7 +792,11 @@ class StandardFiltersTest extends TestCase
 		$data = array(
 			array(
 				'',
-				array(0 => ''),
+				array(),
+			),
+			array(
+				null,
+				array(),
 			),
 			array(
 				'two-one-three',


### PR DESCRIPTION
This aligns the behaviour of the split filter with that of Shopify/Ruby Liquid. This allows for the creation of empty arrays that variables/etc can then be pushed onto. For example,

```
{% assign posts = "" | split: "," %}
{% assign posts = posts | push: featured_post %}
{% assign posts = posts | push: post %}
```

- [x] I've run the tests with `vendor/bin/phpunit`
- [x] None of the tests were found failing
- [x] I've seen the coverage report at `build/coverage/index.html`
- [x] Not a single line left uncovered by tests
- [x] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`
