### PR TITLE
Update phpunit.xml.dist

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,23 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap="vendor/autoload.php"
-    colors="true"
-    verbose="true"
-    executionOrder="random"
-    resolveDependencies="true"
-    failOnRisky="true"
-    failOnWarning="true"
-    backupStaticAttributes="true"
->
-	<testsuites>
-		<testsuite name="Main">
-			<directory>tests/</directory>
-		</testsuite>
-	</testsuites>
-
-	<filter>
-		<whitelist>
-			<directory suffix=".php">src/</directory>
-		</whitelist>
-	</filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" verbose="true" executionOrder="random" resolveDependencies="true" failOnRisky="true" failOnWarning="true" backupStaticAttributes="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Main">
+      <directory>tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
This is the result of running `phpunit --migrate-configuration`

**Fixes**
```
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
```
