### PR TITLE
Improve performance

### DIFF
--- a/src/Liquid/AbstractBlock.php
+++ b/src/Liquid/AbstractBlock.php
@@ -55,7 +55,7 @@ class AbstractBlock extends AbstractTag
 		$tags = Template::getTags();
 
 		if (!isset(Liquid::$config['tokenRegex'])) {
-			Liquid::$config['tokenRegex'] = '/(' . Liquid::$config['TAG_START'] . ')?(?(1)(' . Liquid::$config['WHITESPACE_CONTROL'] . ')?\s*(\w+)|(' . Liquid::$config['VARIABLE_START'] . ')(-' . Liquid::$config['WHITESPACE_CONTROL'] . ')?)\s*(.*?)\s*(' . Liquid::$config['WHITESPACE_CONTROL'] . ')?((?(1)' . Liquid::$config['TAG_END'] . '|' . Liquid::$config['VARIABLE_END'] . '))/s';
+			Liquid::$config['tokenRegex'] = '/(' . Liquid::$config['TAG_START'] . ')?(?(1)(' . Liquid::$config['WHITESPACE_CONTROL'] . ')?\s*(\w+)|(' . Liquid::$config['VARIABLE_START'] . ')(' . Liquid::$config['WHITESPACE_CONTROL'] . ')?)\s*(.*?)\s*(' . Liquid::$config['WHITESPACE_CONTROL'] . ')?((?(1)' . Liquid::$config['TAG_END'] . '|' . Liquid::$config['VARIABLE_END'] . '))/s';
 		}
 
 		for ($i = 0, $n = count($tokens); $i < $n; $i++) {

--- a/src/Liquid/AbstractBlock.php
+++ b/src/Liquid/AbstractBlock.php
@@ -51,16 +51,20 @@ class AbstractBlock extends AbstractTag
 	 */
 	public function parse(array &$tokens)
 	{
-		$startRegexp = new Regexp('/^' . Liquid::get('TAG_START') . '/');
-		$tagRegexp = new Regexp('/^' . Liquid::get('TAG_START') . Liquid::get('WHITESPACE_CONTROL') . '?\s*(\w+)\s*(.*?)' . Liquid::get('WHITESPACE_CONTROL') . '?' . Liquid::get('TAG_END') . '$/s');
-		$variableStartRegexp = new Regexp('/^' . Liquid::get('VARIABLE_START') . '/');
+		$startRegexp = new Regexp('/^' . Liquid::$config['TAG_START'] . '/');
+		$tagRegexp = new Regexp('/^' . Liquid::$config['TAG_START'] . Liquid::$config['WHITESPACE_CONTROL'] . '?\s*(\w+)\s*(.*?)' . Liquid::$config['WHITESPACE_CONTROL'] . '?' . Liquid::$config['TAG_END'] . '$/s');
+		$variableStartRegexp = new Regexp('/^' . Liquid::$config['VARIABLE_START'] . '/');
 
 		$this->nodelist = array();
 
 		$tags = Template::getTags();
 
-		while (count($tokens)) {
-			$token = array_shift($tokens);
+		for ($i = 0, $n = count($tokens); $i < $n; $i++) {
+			if ($tokens[$i] === null) {
+				continue;
+			}
+			$token = $tokens[$i];
+			$tokens[$i] = null;
 
 			if ($startRegexp->match($token)) {
 				$this->whitespaceHandler($token);
@@ -118,7 +122,7 @@ class AbstractBlock extends AbstractTag
 		 * This assumes that TAG_START is always '{%', and a whitespace control indicator
 		 * is exactly one character long, on a third position.
 		 */
-		if (mb_substr($token, 2, 1) === Liquid::get('WHITESPACE_CONTROL')) {
+		if ($token[2] === Liquid::$config['WHITESPACE_CONTROL']) {
 			$previousToken = end($this->nodelist);
 			if (is_string($previousToken)) { // this can also be a tag or a variable
 				$this->nodelist[key($this->nodelist)] = rtrim($previousToken);
@@ -129,7 +133,7 @@ class AbstractBlock extends AbstractTag
 		 * This assumes that TAG_END is always '%}', and a whitespace control indicator
 		 * is exactly one character long, on a third position from the end.
 		 */
-		self::$trimWhitespace = mb_substr($token, -3, 1) === Liquid::get('WHITESPACE_CONTROL');
+		self::$trimWhitespace = $token[-3] === Liquid::$config['WHITESPACE_CONTROL'];
 	}
 
 	/**
@@ -254,7 +258,7 @@ class AbstractBlock extends AbstractTag
 	 */
 	private function createVariable($token)
 	{
-		$variableRegexp = new Regexp('/^' . Liquid::get('VARIABLE_START') . Liquid::get('WHITESPACE_CONTROL') . '?(.*?)' . Liquid::get('WHITESPACE_CONTROL') . '?' . Liquid::get('VARIABLE_END') . '$/s');
+		$variableRegexp = new Regexp('/^' . Liquid::$config['VARIABLE_START'] . Liquid::$config['WHITESPACE_CONTROL'] . '?(.*?)' . Liquid::$config['WHITESPACE_CONTROL'] . '?' . Liquid::$config['VARIABLE_END'] . '$/s');
 		if ($variableRegexp->match($token)) {
 			return new Variable($variableRegexp->matches[1]);
 		}

--- a/src/Liquid/Tag/TagExtends.php
+++ b/src/Liquid/Tag/TagExtends.php
@@ -81,6 +81,9 @@ class TagExtends extends AbstractTag
 		$name = null;
 
 		foreach ($tokens as $token) {
+			if ($token === null) {
+				continue;
+			}
 			if ($blockstartRegexp->match($token)) {
 				$name = $blockstartRegexp->matches[1];
 				$b[$name] = array();

--- a/src/Liquid/Tag/TagRaw.php
+++ b/src/Liquid/Tag/TagRaw.php
@@ -36,8 +36,12 @@ class TagRaw extends AbstractBlock
 
 		$this->nodelist = array();
 
-		while (count($tokens)) {
-			$token = array_shift($tokens);
+		for ($i = 0, $n = count($tokens); $i < $n; $i++) {
+			if ($tokens[$i] === null) {
+				continue;
+			}
+			$token = $tokens[$i];
+			$tokens[$i] = null;
 
 			if ($tagRegexp->match($token)) {
 				// If we found the proper block delimiter just end parsing here and let the outer block proceed

--- a/tests/Liquid/AbstractBlockTest.php
+++ b/tests/Liquid/AbstractBlockTest.php
@@ -15,13 +15,6 @@ use Liquid\TestCase;
 
 class AbstractBlockTest extends TestCase
 {
-	public function testUnterminatedBlockError()
-	{
-		$this->expectException(\Liquid\Exception\ParseException::class);
-
-		$this->assertTemplateResult('', '{% block }');
-	}
-
 	public function testWhitespaceHandler()
 	{
 		$this->assertTemplateResult('foo', '{% if true %}foo{% endif %}');


### PR DESCRIPTION
I have identified three main bottlenecks when proofing the code with xdebug:

1. `array_shift()`: The array of tokens ended up being  renumbered on each iteration. So we instead set consumed tokens to `null`.
2. `mb_substr()`: Using mutltibyte here is unnecessary and overkill, when we can just operate directly on the string.
3. `Liquid::get()`:  This one surprised me, but due to the number of calls, here it is. Shave off more processing time by accessing the config array directly.

