### PR TITLE
add support for `json` filter

### DIFF
--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -151,6 +151,19 @@ class StandardFilters
 
 
 	/**
+	 * Converts into JSON string
+	 *
+	 * @param mixed $input
+	 *
+	 * @return string
+	 */
+	public static function json($input)
+	{
+		return json_encode($input);
+	}
+
+
+	/**
 	 * Escape a string
 	 *
 	 * @param string $input

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -174,6 +174,36 @@ class StandardFiltersTest extends TestCase
 		}
 	}
 
+	public function testJson()
+	{
+		$data = array(
+			array(
+				"before" => "Anything",
+				"after" => "\"Anything\"",
+			),
+			array(
+				"before" => 3,
+				"after" => 3,
+			),
+			array(
+				"before" => array(1, 2, 3),
+				"after" => "[1,2,3]",
+			),
+			array(
+				"before" => array("one" => 1, "two" => 2, "three" => 3),
+				"after" => "{\"one\":1,\"two\":2,\"three\":3}",
+			),
+			array(
+				"before" => array("one" => 1, "two" => array(1, 2, 3), "three" => 3),
+				"after" => "{\"one\":1,\"two\":[1,2,3],\"three\":3}",
+			),
+		);
+
+		foreach ($data as $testCase) {
+			$this->assertEquals($testCase['after'], StandardFilters::json($testCase['before']));
+		}
+	}
+
 	public function testEscape()
 	{
 		$data = array(


### PR DESCRIPTION
Adds support for [json](https://liquidjs.com/filters/json.html) filter:

```
{{ item | json }}
```

---

- [x] I've run the tests with `vendor/bin/phpunit`
- [x] None of the tests were found failing
- [ ] I've seen the coverage report at `build/coverage/index.html`
- [x] Not a single line left uncovered by tests
- [x] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`
