### PR TITLE
Fix Array to string conversion

### DIFF
--- a/src/Liquid/AbstractBlock.php
+++ b/src/Liquid/AbstractBlock.php
@@ -164,7 +164,7 @@ class AbstractBlock extends AbstractTag
 			}
 
 			if (is_array($value)) {
-				$value = htmlspecialchars(implode($value));
+				$value = $this->arrayToString($value);
 			}
 
 			$result .= $value;
@@ -180,6 +180,21 @@ class AbstractBlock extends AbstractTag
 		}
 
 		return $result;
+	}
+	
+	protected function arrayToString($value)
+	{
+		$result = [];
+		
+		foreach ($value as $item) {
+			if (is_array($item)) {
+				$result[] = $this->arrayToString($item);
+			} else {
+				$result[] = htmlspecialchars($item);
+			}
+		}
+	
+		return implode(', ', $result);
 	}
 
 	/**


### PR DESCRIPTION
If you try to render a multi-level array it will throw an Array to string conversion exception.

```php
[
    'example' => ['name' => 'test', 'address' => []]
];
```
```
{{  example }}
```

This will recursively implode the array. 

- [ ] I've run the tests with `vendor/bin/phpunit`
- [ ] None of the tests were found failing
- [ ] I've seen the coverage report at `build/coverage/index.html`
- [ ] Not a single line left uncovered by tests
- [ ] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`
