### PR TITLE
Fix split filter for php >=8.0 in case of empty separator

### DIFF
--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -625,10 +625,6 @@ class StandardFilters
 			return mb_str_split($input);
 		}
 
-		if (empty($pattern)) {
-			return [$input];
-		}
-
 		return explode($pattern, $input);
 	}
 

--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -621,6 +621,14 @@ class StandardFilters
 			return [];
 		}
 
+		if ($pattern === '') {
+			return mb_str_split($input);
+		}
+
+		if (empty($pattern)) {
+			return [$input];
+		}
+
 		return explode($pattern, $input);
 	}
 

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -867,19 +867,32 @@ class StandardFiltersTest extends TestCase
 			array(
 				'',
 				array(),
+				'-'
 			),
 			array(
 				null,
 				array(),
+				'-'
 			),
 			array(
 				'two-one-three',
 				array('two', 'one', 'three'),
+				'-'
 			),
+			array(
+				'phrase',
+				array('p', 'h', 'r', 'a', 's', 'e'),
+				''
+			),
+			array(
+				'phrase',
+				array('phrase'),
+				null
+			)
 		);
 
 		foreach ($data as $item) {
-			$this->assertEquals($item[1], StandardFilters::split($item[0], '-'));
+			$this->assertEquals($item[1], StandardFilters::split($item[0], $item[2]));
 		}
 	}
 

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -892,11 +892,6 @@ class StandardFiltersTest extends TestCase
 				null
 			),
 			array(
-				'12301230123',
-				array('123', '123', '123'),
-				'0'
-			),
-			array(
 				'123 123 123',
 				array('123', '123', '123'),
 				' '

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -867,17 +867,14 @@ class StandardFiltersTest extends TestCase
 			array(
 				'',
 				array(),
-				'-'
 			),
 			array(
 				null,
 				array(),
-				'-'
 			),
 			array(
 				'two-one-three',
 				array('two', 'one', 'three'),
-				'-'
 			),
 			array(
 				'12301230123',
@@ -885,7 +882,7 @@ class StandardFiltersTest extends TestCase
 				'0'
 			),
 			array(
-        'phrase',
+				'phrase',
 				array('p', 'h', 'r', 'a', 's', 'e'),
 				''
 			),

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -890,7 +890,17 @@ class StandardFiltersTest extends TestCase
 				'phrase',
 				array('phrase'),
 				null
-			)
+			),
+			array(
+				'12301230123',
+				array('123', '123', '123'),
+				'0'
+			),
+			array(
+				'123 123 123',
+				array('123', '123', '123'),
+				' '
+			),
 		);
 
 		foreach ($data as $item) {


### PR DESCRIPTION
For php >8.0 split filter throws ValueError when separator parameter is an empty string.

- [x] I've run the tests with `vendor/bin/phpunit` (php 8.2)
- [x] None of the tests were found failing
- [ ] I've seen the coverage report at `build/coverage/index.html`
- [ ] Not a single line left uncovered by tests
- [x] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`
