### PR TITLE
Fix: htmlentities() shouldn't be called with null

### DIFF
--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -201,6 +201,10 @@ class StandardFilters
 			return $input;
 		}
 
+		if (is_null($input)) {
+			return $input;
+		}
+
 		return htmlentities($input, ENT_QUOTES);
 	}
 

--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -202,7 +202,7 @@ class StandardFilters
 		}
 
 		if (is_null($input)) {
-			return $input;
+			return '';
 		}
 
 		return htmlentities($input, ENT_QUOTES);

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -231,6 +231,7 @@ class StandardFiltersTest extends TestCase
 		$data = array(
 			"one Word's not" => "one Word&#039;s not",
 			"&><\"'" => "&amp;&gt;&lt;&quot;&#039;",
+			null => null,
 		);
 
 		foreach ($data as $element => $expected) {

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -231,7 +231,7 @@ class StandardFiltersTest extends TestCase
 		$data = array(
 			"one Word's not" => "one Word&#039;s not",
 			"&><\"'" => "&amp;&gt;&lt;&quot;&#039;",
-			null => null,
+			null => '',
 		);
 
 		foreach ($data as $element => $expected) {


### PR DESCRIPTION
Fix: htmlentities(): Passing null to parameter #1 ($string) of type string is deprecated

- [X] I've run the tests with `vendor/bin/phpunit`
- [X] None of the tests were found failing
- [X] I've seen the coverage report at `build/coverage/index.html`
- [X] Not a single line left uncovered by tests
- [X] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`
