### PR TITLE
AbstractTag: add cached instance of the config, to improve performance

### DIFF
--- a/src/Liquid/AbstractTag.php
+++ b/src/Liquid/AbstractTag.php
@@ -38,6 +38,13 @@ abstract class AbstractTag
 	protected $attributes = array();
 
 	/**
+	 * A cached instance of the config array, for performance reasons.
+	 *
+	 * @var array
+	 */
+	protected $config = array();
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $markup
@@ -48,6 +55,8 @@ abstract class AbstractTag
 	{
 		$this->markup = $markup;
 		$this->fileSystem = $fileSystem;
+		$this->config = &Liquid::$config;
+
 		$this->parse($tokens);
 	}
 


### PR DESCRIPTION
- [x] I've run the tests with `vendor/bin/phpunit`
- [x] None of the tests were found failing
- [x] I've seen the coverage report at `build/coverage/index.html`
- [x] Not a single line left uncovered by tests
- [x] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`
