### PR TITLE
Improve PHP-CS-Fixer configuration

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Liquid package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package Liquid
+ */
+
 $header = <<<'EOF'
 This file is part of the Liquid package.
 
@@ -11,6 +20,7 @@ EOF;
 
 $config = new PhpCsFixer\Config();
 $config
+	->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
 	->setRiskyAllowed(true)
 	->setRules([
 		'@PSR2' => true,
@@ -40,6 +50,7 @@ $config
 	->setFinder(
 		PhpCsFixer\Finder::create()
 		->in(__DIR__)
+		->append([__FILE__])
 	)
 ;
 


### PR DESCRIPTION
- [x] I've run the tests with `vendor/bin/phpunit`
- [x] None of the tests were found failing
- [x] I've seen the coverage report at `build/coverage/index.html`
- [x] Not a single line left uncovered by tests
- [x] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`
