### PR TITLE
Ensure all subclasses of AbstractTag always call the constructor

### DIFF
--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -42,6 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer update --prefer-dist --no-interaction --no-progress ${{ matrix.dependencies }}
+          composer dump-autoload --optimize
 
       - name: Run mutation testing
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,6 +56,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer update --prefer-dist --no-interaction --no-progress ${{ matrix.dependencies }}
+          composer dump-autoload --optimize
 
       - name: Run tests
         run: |

--- a/src/Liquid/Document.php
+++ b/src/Liquid/Document.php
@@ -28,8 +28,7 @@ class Document extends AbstractBlock
 	 */
 	public function __construct(array &$tokens, ?FileSystem $fileSystem = null)
 	{
-		$this->fileSystem = $fileSystem;
-		$this->parse($tokens);
+		parent::__construct('', $tokens, $fileSystem);
 	}
 
 	/**

--- a/src/Liquid/Tag/TagAssign.php
+++ b/src/Liquid/Tag/TagAssign.php
@@ -50,6 +50,8 @@ class TagAssign extends AbstractTag
 	 */
 	public function __construct($markup, array &$tokens, ?FileSystem $fileSystem = null)
 	{
+		parent::__construct($markup, $tokens, $fileSystem);
+
 		$syntaxRegexp = new Regexp('/(\w+)\s*=\s*(.*)\s*/');
 
 		if ($syntaxRegexp->match($markup)) {

--- a/src/Liquid/Tag/TagCycle.php
+++ b/src/Liquid/Tag/TagCycle.php
@@ -57,6 +57,8 @@ class TagCycle extends AbstractTag
 	 */
 	public function __construct($markup, array &$tokens, ?FileSystem $fileSystem = null)
 	{
+		parent::__construct($markup, $tokens, $fileSystem);
+
 		$simpleSyntax = new Regexp("/" . Liquid::get('QUOTED_FRAGMENT') . "/");
 		$namedSyntax = new Regexp("/(" . Liquid::get('QUOTED_FRAGMENT') . ")\s*\:\s*(.*)/");
 

--- a/src/Liquid/Tag/TagDecrement.php
+++ b/src/Liquid/Tag/TagDecrement.php
@@ -47,6 +47,8 @@ class TagDecrement extends AbstractTag
 	 */
 	public function __construct($markup, array &$tokens, ?FileSystem $fileSystem = null)
 	{
+		parent::__construct($markup, $tokens, $fileSystem);
+
 		$syntax = new Regexp('/(' . Liquid::get('VARIABLE_NAME') . ')/');
 
 		if ($syntax->match($markup)) {

--- a/src/Liquid/Tag/TagIncrement.php
+++ b/src/Liquid/Tag/TagIncrement.php
@@ -47,6 +47,8 @@ class TagIncrement extends AbstractTag
 	 */
 	public function __construct($markup, array &$tokens, ?FileSystem $fileSystem = null)
 	{
+		parent::__construct($markup, $tokens, $fileSystem);
+
 		$syntax = new Regexp('/(' . Liquid::get('VARIABLE_NAME') . ')/');
 
 		if ($syntax->match($markup)) {

--- a/tests/Liquid/StaticAnalysisTest.php
+++ b/tests/Liquid/StaticAnalysisTest.php
@@ -71,6 +71,10 @@ class StaticAnalysisTest extends TestCase
 				continue;
 			}
 
+			if ($refClass->getMethod('__construct')->getDeclaringClass()->getName() === AbstractTag::class) {
+				continue; // Skip if the constructor is not overridden
+			}
+
 			yield $class => [...$data, $refClass];
 		}
 	}
@@ -89,13 +93,15 @@ class StaticAnalysisTest extends TestCase
 
 		$code = array_slice(file($refMethod->getFileName()), $startLine - 1, $endLine - $startLine + 1);
 
-		$code = array_filter($code, function ($line) {
+		$this->assertNotEmpty($code);
+
+		$linesWithConstruct = array_filter($code, function ($line) {
 			return strpos($line, 'parent::__construct') !== false;
 		});
 
 		$this->assertNotEmpty(
-			$code,
-			"The constructor of $class should call parent::__construct()"
+			$linesWithConstruct,
+			"The constructor of {$refClass->getName()} should call parent::__construct()"
 		);
 	}
 }

--- a/tests/Liquid/StaticAnalysisTest.php
+++ b/tests/Liquid/StaticAnalysisTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Liquid package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package Liquid
+ */
+
+namespace Liquid;
+
+use ReflectionClass;
+use function array_filter;
+use function class_exists;
+use function file;
+use function interface_exists;
+use function join;
+use function trait_exists;
+use function var_dump;
+
+/**
+ * @coversNothing
+ */
+class StaticAnalysisTest extends TestCase
+{
+	/**
+	 * @return iterable
+	 */
+	public static function provideClasses()
+	{
+		$files = require 'vendor/composer/autoload_classmap.php';
+
+		$seenNonVendor = false;
+		foreach ($files as $class => $filename) {
+			$path = str_replace(getcwd(), '.', $filename);
+
+			if (strpos($path, './vendor/') === 0) {
+				continue;
+			}
+
+			$seenNonVendor = true;
+			yield $class => [str_replace(getcwd(), '.', $filename), $class];
+		}
+
+		if ($seenNonVendor === false) {
+			throw new \RuntimeException('Please generate the classmap.');
+		}
+	}
+
+	/**
+	 * @dataProvider provideClasses
+	 * @param mixed $filename
+	 * @param mixed $class
+	 */
+	public function testClassExists($filename, $class)
+	{
+		$this->assertTrue(class_exists($class) || trait_exists($class) || interface_exists($class));
+	}
+
+	public static function provideAbstractTagSubclasses()
+	{
+		foreach (self::provideClasses() as $class => $data) {
+			if (!is_subclass_of($class, AbstractTag::class)) {
+				continue;
+			}
+
+			$refClass = new ReflectionClass($class);
+			if (!$refClass->hasMethod('__construct')) {
+				continue;
+			}
+
+			yield $class => [...$data, $refClass];
+		}
+	}
+
+	/**
+	 * @dataProvider provideAbstractTagSubclasses
+	 * @param string $filename
+	 * @param class-string<AbstractTag> $class
+	 * @param ReflectionClass<AbstractTag> $refClass
+	 */
+	public function testAbstractTagChildCallsConstruct($filename, $class, ReflectionClass $refClass)
+	{
+		$refMethod = $refClass->getMethod('__construct');
+		$startLine = $refMethod->getStartLine();
+		$endLine = $refMethod->getEndLine();
+
+		$code = array_slice(file($refMethod->getFileName()), $startLine - 1, $endLine - $startLine + 1);
+
+		$code = array_filter($code, function ($line) {
+			return strpos($line, 'parent::__construct') !== false;
+		});
+
+		$this->assertNotEmpty(
+			$code,
+			"The constructor of $class should call parent::__construct()"
+		);
+	}
+}


### PR DESCRIPTION
- [x] I've run the tests with `vendor/bin/phpunit`
- [x] None of the tests were found failing
- [x] I've seen the coverage report at `build/coverage/index.html`
- [x] Not a single line left uncovered by tests
- [x] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`
