### PR TITLE
Fix filter compatibility's

### DIFF
--- a/src/Liquid/Liquid.php
+++ b/src/Liquid/Liquid.php
@@ -151,20 +151,44 @@ class Liquid
 	 * Flatten a multidimensional array into a single array. Does not maintain keys.
 	 *
 	 * @param array $array
+	 * @param bool $skipHash If true, associative arrays (hashes) are preserved without flattening.
+	 *                       This mimics Ruby's Array#flatten behavior which preserves Hash objects.
 	 *
 	 * @return array
 	 */
-	public static function arrayFlatten($array)
+	public static function arrayFlatten($array, $skipHash = false)
 	{
 		$return = [];
 
 		foreach ($array as $element) {
 			if (is_array($element)) {
-				$return = array_merge($return, self::arrayFlatten($element));
+				if ($skipHash && self::isHash($element)) {
+					$return[] = $element;
+				} else {
+					$return = array_merge($return, self::arrayFlatten($element, $skipHash));
+				}
 			} else {
 				$return[] = $element;
 			}
 		}
 		return $return;
+	}
+
+	/**
+	 * Determine if an array is a hash (associative array).
+	 * This is a polyfill for !array_is_list() (PHP 8.1+).
+	 *
+	 * @param array $array
+	 *
+	 * @return bool
+	 *
+	 * @see https://www.php.net/manual/en/function.array-is-list.php
+	 */
+	public static function isHash(array $array): bool
+	{
+		if (empty($array)) {
+			return false;
+		}
+		return array_keys($array) !== range(0, count($array) - 1);
 	}
 }

--- a/src/Liquid/Liquid.php
+++ b/src/Liquid/Liquid.php
@@ -191,4 +191,25 @@ class Liquid
 		}
 		return array_keys($array) !== range(0, count($array) - 1);
 	}
+
+	/**
+	 * Determine if a value represents an integer.
+	 * Returns true for int type or string integers (e.g., "20", "-5").
+	 * Returns false for floats (e.g., 20.0) to preserve float division behavior.
+	 *
+	 * @param mixed $value
+	 *
+	 * @return bool
+	 */
+	public static function isInteger($value): bool
+	{
+		if (is_int($value)) {
+			return true;
+		}
+		if (is_string($value)) {
+			$trimmed = ltrim($value, '-');
+			return $trimmed !== '' && ctype_digit($trimmed);
+		}
+		return false;
+	}
 }

--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -34,7 +34,7 @@ class StandardFilters
 
 
 	/**
-	 * Capitalize words in the input sentence
+	 * Capitalize the first character and downcase the rest
 	 *
 	 * @param string $input
 	 *
@@ -42,10 +42,9 @@ class StandardFilters
 	 */
 	public static function capitalize($input)
 	{
-		return preg_replace_callback("/(^|[^\p{L}'])([\p{Ll}])/u", function ($matches) {
-			$first_char = mb_substr($matches[2], 0, 1);
-			return $matches[1] . mb_strtoupper($first_char) . mb_substr($matches[2], 1);
-		}, ucwords($input));
+		$firstChar = mb_strtoupper(mb_substr($input, 0, 1, 'UTF-8'), 'UTF-8');
+		$rest = mb_strtolower(mb_substr($input, 1, null, 'UTF-8'), 'UTF-8');
+		return $firstChar . $rest;
 	}
 
 

--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -111,16 +111,19 @@ class StandardFilters
 
 
 	/**
-	 * division
+	 * Division
 	 *
-	 * @param float $input
-	 * @param float $operand
+	 * @param int|float|string $input
+	 * @param int|float|string $operand
 	 *
-	 * @return float
+	 * @return int|float
 	 */
 	public static function divided_by($input, $operand)
 	{
-		return (float)$input / (float)$operand;
+		if (Liquid::isInteger($input) && Liquid::isInteger($operand)) {
+			return (int) floor($input / $operand);
+		}
+		return (float) $input / (float) $operand;
 	}
 
 
@@ -347,29 +350,35 @@ class StandardFilters
 
 
 	/**
-	 * subtraction
+	 * Subtraction
 	 *
-	 * @param float $input
-	 * @param float $operand
+	 * @param int|float|string $input
+	 * @param int|float|string $operand
 	 *
-	 * @return float
+	 * @return int|float
 	 */
 	public static function minus($input, $operand)
 	{
+		if (Liquid::isInteger($input) && Liquid::isInteger($operand)) {
+			return (int)$input - (int)$operand;
+		}
 		return (float)$input - (float)$operand;
 	}
 
 
 	/**
-	 * modulo
+	 * Modulo
 	 *
-	 * @param float $input
-	 * @param float $operand
+	 * @param int|float|string $input
+	 * @param int|float|string $operand
 	 *
-	 * @return float
+	 * @return int|float
 	 */
 	public static function modulo($input, $operand)
 	{
+		if (Liquid::isInteger($input) && Liquid::isInteger($operand)) {
+			return (int)$input % (int)$operand;
+		}
 		return fmod((float)$input, (float)$operand);
 	}
 
@@ -388,15 +397,18 @@ class StandardFilters
 
 
 	/**
-	 * addition
+	 * Addition
 	 *
-	 * @param float $input
-	 * @param float $operand
+	 * @param int|float|string $input
+	 * @param int|float|string $operand
 	 *
-	 * @return float
+	 * @return int|float
 	 */
 	public static function plus($input, $operand)
 	{
+		if (Liquid::isInteger($input) && Liquid::isInteger($operand)) {
+			return (int)$input + (int)$operand;
+		}
 		return (float)$input + (float)$operand;
 	}
 
@@ -682,15 +694,18 @@ class StandardFilters
 
 
 	/**
-	 * multiplication
+	 * Multiplication
 	 *
-	 * @param float $input
-	 * @param float $operand
+	 * @param int|float|string $input
+	 * @param int|float|string $operand
 	 *
-	 * @return float
+	 * @return int|float
 	 */
 	public static function times($input, $operand)
 	{
+		if (Liquid::isInteger($input) && Liquid::isInteger($operand)) {
+			return (int)$input * (int)$operand;
+		}
 		return (float)$input * (float)$operand;
 	}
 

--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -316,7 +316,7 @@ class StandardFilters
 	 * @param array|\Traversable $input
 	 * @param string $property
 	 *
-	 * @return string
+	 * @return mixed
 	 */
 	public static function map($input, $property)
 	{
@@ -326,6 +326,15 @@ class StandardFilters
 		if (!is_array($input)) {
 			return $input;
 		}
+
+		if (Liquid::isHash($input)) {
+			$input = [$input];
+		}
+
+		// Flatten nested arrays while preserving hashes
+		// [[['attr' => 1]]] => [['attr' => 1]]
+		$input = Liquid::arrayFlatten($input, true);
+
 		return array_map(function ($elem) use ($property) {
 			if (is_callable($elem)) {
 				return $elem();

--- a/tests/Liquid/LiquidTest.php
+++ b/tests/Liquid/LiquidTest.php
@@ -85,4 +85,62 @@ class LiquidTest extends TestCase
 
 		$this->assertEquals($expected, Liquid::arrayFlatten($original));
 	}
+
+	public function testArrayFlattenSkipHash()
+	{
+		$original = [
+			[['attr' => 1], ['attr' => 2]],
+			[['attr' => 3]],
+		];
+
+		$expected = [
+			['attr' => 1],
+			['attr' => 2],
+			['attr' => 3],
+		];
+
+		$this->assertEquals($expected, Liquid::arrayFlatten($original, true));
+	}
+
+	public function testArrayFlattenSkipHashMixedContent()
+	{
+		$original = [
+			['name' => 'John', 'age' => 30],
+			[1, 2, 3],
+			['key' => 'value'],
+		];
+
+		$expected = [
+			['name' => 'John', 'age' => 30],
+			1,
+			2,
+			3,
+			['key' => 'value'],
+		];
+
+		$this->assertEquals($expected, Liquid::arrayFlatten($original, true));
+	}
+
+	public function testIsHashWithEmptyArray()
+	{
+		$this->assertFalse(Liquid::isHash([]));
+	}
+
+	public function testIsHashWithIndexedArray()
+	{
+		$this->assertFalse(Liquid::isHash(['a', 'b', 'c']));
+		$this->assertFalse(Liquid::isHash([0 => 'a', 1 => 'b', 2 => 'c']));
+	}
+
+	public function testIsHashWithAssociativeArray()
+	{
+		$this->assertTrue(Liquid::isHash(['name' => 'John']));
+		$this->assertTrue(Liquid::isHash(['a' => 1, 'b' => 2]));
+	}
+
+	public function testIsHashWithNonSequentialKeys()
+	{
+		$this->assertTrue(Liquid::isHash([1 => 'a', 2 => 'b']));
+		$this->assertTrue(Liquid::isHash([0 => 'a', 2 => 'b']));
+	}
 }

--- a/tests/Liquid/LiquidTest.php
+++ b/tests/Liquid/LiquidTest.php
@@ -143,4 +143,41 @@ class LiquidTest extends TestCase
 		$this->assertTrue(Liquid::isHash([1 => 'a', 2 => 'b']));
 		$this->assertTrue(Liquid::isHash([0 => 'a', 2 => 'b']));
 	}
+
+	public function testIsIntegerWithIntType()
+	{
+		$this->assertTrue(Liquid::isInteger(20));
+		$this->assertTrue(Liquid::isInteger(0));
+		$this->assertTrue(Liquid::isInteger(-5));
+	}
+
+	public function testIsIntegerWithStringInteger()
+	{
+		$this->assertTrue(Liquid::isInteger('20'));
+		$this->assertTrue(Liquid::isInteger('0'));
+		$this->assertTrue(Liquid::isInteger('-5'));
+	}
+
+	public function testIsIntegerWithFloat()
+	{
+		$this->assertFalse(Liquid::isInteger(20.0));
+		$this->assertFalse(Liquid::isInteger(20.5));
+		$this->assertFalse(Liquid::isInteger(-5.0));
+	}
+
+	public function testIsIntegerWithStringFloat()
+	{
+		$this->assertFalse(Liquid::isInteger('20.0'));
+		$this->assertFalse(Liquid::isInteger('20.5'));
+		$this->assertFalse(Liquid::isInteger('-5.5'));
+	}
+
+	public function testIsIntegerWithInvalidValues()
+	{
+		$this->assertFalse(Liquid::isInteger(''));
+		$this->assertFalse(Liquid::isInteger('-'));
+		$this->assertFalse(Liquid::isInteger('abc'));
+		$this->assertFalse(Liquid::isInteger(null));
+		$this->assertFalse(Liquid::isInteger([]));
+	}
 }

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -129,11 +129,11 @@ class StandardFiltersTest extends TestCase
 	public function testCapitalize()
 	{
 		$data = [
-			'one Word not' => 'One Word Not',
-			'1test' => '1Test',
+			'one Word not' => 'One word not',
+			'1test' => '1test',
 			'' => '',
 			// UTF-8
-			'владимир владимирович' => 'Владимир Владимирович',
+			'владимир владимирович' => 'Владимир владимирович',
 		];
 
 		foreach ($data as $element => $expected) {

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -765,6 +765,14 @@ class StandardFiltersTest extends TestCase
 				0,
 				0,
 			],
+			[
+				['attr' => 'single value'],
+				['single value'],
+			],
+			[
+				[[['attr' => 1], ['attr' => 2]], [['attr' => 3]]],
+				[1, 2, 3],
+			],
 		];
 
 		foreach ($data as $item) {

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -982,19 +982,46 @@ class StandardFiltersTest extends TestCase
 	{
 		$data = [
 			[
-				'',
-				'',
-				0,
+				1,
+				1,
+				2,
+			],
+			[
+				'3',
+				'4',
+				7,
+			],
+			[
+				'-5',
+				'3',
+				-2,
 			],
 			[
 				10,
 				20,
 				30,
 			],
+		];
+
+		foreach ($data as $item) {
+			$this->assertSame($item[2], StandardFilters::plus($item[0], $item[1]));
+		}
+
+		$data = [
+			[
+				'1',
+				'1.0',
+				2.0,
+			],
 			[
 				1.5,
 				2.7,
 				4.2,
+			],
+			[
+				'',
+				'',
+				0.0,
 			],
 		];
 
@@ -1007,14 +1034,31 @@ class StandardFiltersTest extends TestCase
 	{
 		$data = [
 			[
-				'',
-				'',
-				0,
+				5,
+				1,
+				4,
+			],
+			[
+				'10',
+				'3',
+				7,
 			],
 			[
 				10,
 				20,
 				-10,
+			],
+		];
+
+		foreach ($data as $item) {
+			$this->assertSame($item[2], StandardFilters::minus($item[0], $item[1]));
+		}
+
+		$data = [
+			[
+				'4.3',
+				'2',
+				2.3,
 			],
 			[
 				1.5,
@@ -1024,7 +1068,12 @@ class StandardFiltersTest extends TestCase
 			[
 				3.1,
 				3.1,
-				0,
+				0.0,
+			],
+			[
+				'',
+				'',
+				0.0,
 			],
 		];
 
@@ -1037,14 +1086,46 @@ class StandardFiltersTest extends TestCase
 	{
 		$data = [
 			[
-				'',
-				'',
-				0,
+				3,
+				4,
+				12,
+			],
+			[
+				'5',
+				'2',
+				10,
+			],
+			[
+				-3,
+				4,
+				-12,
 			],
 			[
 				10,
 				20,
 				200,
+			],
+		];
+
+		foreach ($data as $item) {
+			$this->assertSame($item[2], StandardFilters::times($item[0], $item[1]));
+		}
+
+		$data = [
+			[
+				0.0725,
+				100,
+				7.25,
+			],
+			[
+				'-0.0725',
+				100,
+				-7.25,
+			],
+			[
+				'-0.0725',
+				-100,
+				7.25,
 			],
 			[
 				1.5,
@@ -1052,9 +1133,14 @@ class StandardFiltersTest extends TestCase
 				4.05,
 			],
 			[
-				  7.5,
-				  0,
-				  0,
+				7.5,
+				0,
+				0.0,
+			],
+			[
+				'',
+				'',
+				0.0,
 			],
 		];
 
@@ -1071,28 +1157,6 @@ class StandardFiltersTest extends TestCase
 				10,
 				2,
 			],
-			[
-				10,
-				20,
-				0.5,
-			],
-			[
-				0,
-				200,
-				0,
-			],
-			[
-				10,
-				0.5,
-				20,
-			],
-		];
-
-		foreach ($data as $item) {
-			$this->assertEqualsWithDelta($item[2], StandardFilters::divided_by($item[0], $item[1]), 0.00001);
-		}
-
-		$data = [
 			[
 				12,
 				3,
@@ -1118,11 +1182,48 @@ class StandardFiltersTest extends TestCase
 		foreach ($data as $item) {
 			$this->assertSame($item[2], StandardFilters::divided_by($item[0], $item[1]));
 		}
+
+		$data = [
+			[
+				'20.0',
+				10,
+				2.0,
+			],
+			[
+				10.0,
+				20,
+				0.5,
+			],
+			[
+				10,
+				20.0,
+				0.5,
+			],
+			[
+				0,
+				200.0,
+				0.0,
+			],
+			[
+				10,
+				0.5,
+				20.0,
+			],
+		];
+
+		foreach ($data as $item) {
+			$this->assertEqualsWithDelta($item[2], StandardFilters::divided_by($item[0], $item[1]), 0.00001);
+		}
 	}
 
 	public function testModulo()
 	{
 		$data = [
+			[
+				'7',
+				'3',
+				1,
+			],
 			[
 				'20',
 				10,
@@ -1138,6 +1239,13 @@ class StandardFiltersTest extends TestCase
 				3,
 				2,
 			],
+		];
+
+		foreach ($data as $item) {
+			$this->assertSame($item[2], StandardFilters::modulo($item[0], $item[1]));
+		}
+
+		$data = [
 			[
 				8.9,
 				3.5,

--- a/tests/Liquid/StandardFiltersTest.php
+++ b/tests/Liquid/StandardFiltersTest.php
@@ -1083,6 +1083,33 @@ class StandardFiltersTest extends TestCase
 		foreach ($data as $item) {
 			$this->assertEqualsWithDelta($item[2], StandardFilters::divided_by($item[0], $item[1]), 0.00001);
 		}
+
+		$data = [
+			[
+				12,
+				3,
+				4,
+			],
+			[
+				14,
+				3,
+				4,
+			],
+			[
+				15,
+				3,
+				5,
+			],
+			[
+				5,
+				3,
+				1,
+			],
+		];
+
+		foreach ($data as $item) {
+			$this->assertSame($item[2], StandardFilters::divided_by($item[0], $item[1]));
+		}
 	}
 
 	public function testModulo()


### PR DESCRIPTION
- [x] I've run the tests with `vendor/bin/phpunit`
- [x] None of the tests were found failing
- [ ] I've seen the coverage report at `build/coverage/index.html`
- [ ] Not a single line left uncovered by tests
- [x] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`

Fix #233 , #234 

### Changes

`capitalize`

- Before: "hello WORLD" → "Hello WORLD"
- After: "hello WORLD" → "Hello world"

`plus, minus, times, modulo, divided_by`

- Before: always returns float
- After: returns int when both operands are integers

`map`

- Single hash and nested arrays are now handled correctly

### What I'd like reviewed
`src/Liquid/Liquid.php::isHash,isInteger`
I'm currently adding utility functions directly to Liquid/Liquid.
I did consider making a separate Liquid/Util module, but I generally avoid creating modules with such broad, generic purposes.
Given the small scope right now, I think keeping them in Liquid/Liquid is fine for the time being.

However, if this section grows significantly, it will definitely require more maintenance. So, I'd appreciate your decision on how to proceed.