### PR TITLE
Fix deprecation str_replace

### DIFF
--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -441,9 +441,9 @@ class StandardFilters
 	/**
 	 * Replace occurrences of a string with another
 	 *
-	 * @param string $input
+	 * @param string|null $input
 	 * @param string|null $string
-	 * @param string $replacement
+	 * @param string|null $replacement
 	 *
 	 * @return string
 	 */
@@ -452,7 +452,7 @@ class StandardFilters
 		if ($string === null) {
 			return $input;
 		}
-		return str_replace($string, $replacement === null ? '' : $replacement, $input);
+		return str_replace($string, (string)$replacement, (string)$input);
 	}
 
 

--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -416,6 +416,9 @@ class StandardFilters
 	 */
 	public static function remove($input, $string)
 	{
+		if ($string === null) {
+			return $input;
+		}
 		return str_replace($string, '', $input);
 	}
 
@@ -449,7 +452,10 @@ class StandardFilters
 	 */
 	public static function replace($input, $string, $replacement = '')
 	{
-		return str_replace($string, $replacement, $input);
+		if ($string === null) {
+			return $input;
+		}
+		return str_replace($string, $replacement === null ? '' : $replacement, $input);
 	}
 
 

--- a/src/Liquid/StandardFilters.php
+++ b/src/Liquid/StandardFilters.php
@@ -410,16 +410,13 @@ class StandardFilters
 	 * Remove a substring
 	 *
 	 * @param string $input
-	 * @param string $string
+	 * @param string|null $string
 	 *
 	 * @return string
 	 */
 	public static function remove($input, $string)
 	{
-		if ($string === null) {
-			return $input;
-		}
-		return str_replace($string, '', $input);
+		return self::replace($input, $string);
 	}
 
 
@@ -445,7 +442,7 @@ class StandardFilters
 	 * Replace occurrences of a string with another
 	 *
 	 * @param string $input
-	 * @param string $string
+	 * @param string|null $string
 	 * @param string $replacement
 	 *
 	 * @return string

--- a/tests/Liquid/OutputTest.php
+++ b/tests/Liquid/OutputTest.php
@@ -224,4 +224,18 @@ class OutputTest extends TestCase
 
 		$this->assertTemplateResult($expected, $text, []);
 	}
+
+	public function testRemoveWithNull(): void
+	{
+		$text = ' {{ best_cars | remove: brand }} ';
+
+		$this->assertTemplateResult(' bmw ', $text, [...$this->assigns, 'brand' => null]);
+	}
+
+	public function testReplaceWithNull()
+	{
+		$text = ' {{ best_cars | replace: brand }} ';
+
+		$this->assertTemplateResult(' bmw ', $text, [...$this->assigns, 'brand' => null]);
+	}
 }


### PR DESCRIPTION
Fix deprecation:
```
PHP Deprecated:  str_replace(): Passing null to parameter #1 ($search) of type array|string is deprecated
```

- [x] I've run the tests with `vendor/bin/phpunit`
- [x] None of the tests were found failing
- [x] I've seen the coverage report at `build/coverage/index.html`
- [x] Not a single line left uncovered by tests
- [x] Any coding standards issues were fixed with `vendor/bin/php-cs-fixer fix`
